### PR TITLE
SLING-8864 - Report authentication errors immediately without looking at the response's body

### DIFF
--- a/src/main/java/org/apache/sling/cli/impl/http/HttpClientFactory.java
+++ b/src/main/java/org/apache/sling/cli/impl/http/HttpClientFactory.java
@@ -16,8 +16,6 @@
  */
 package org.apache.sling.cli.impl.http;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.HttpResponseInterceptor;
@@ -67,16 +65,16 @@ public class HttpClientFactory {
     }
 
     public CloseableHttpClient newClient() {
-        final AtomicReference<String> url = new AtomicReference<>();
+        final String[] urlHolder = new String[1];
         return HttpClients.custom()
                 .setDefaultCredentialsProvider(newCredentialsProvider())
                 .addInterceptorFirst(
                         (HttpRequestInterceptor) (request, context) ->
-                        url.set(((HttpRequestWrapper) request).getOriginal().getRequestLine().getUri())
+                        urlHolder[0] = ((HttpRequestWrapper) request).getOriginal().getRequestLine().getUri()
                 )
                 .addInterceptorFirst((HttpResponseInterceptor) (response, context) -> {
                     if (response.getStatusLine().getStatusCode() == HttpStatus.SC_UNAUTHORIZED) {
-                        throw new IllegalStateException("Please check your authentication details for " + url.get());
+                        throw new IllegalStateException("Server returned a 401 status; please check your authentication details for " + urlHolder[0]);
                     }
                 })
                 .build();

--- a/src/test/java/org/apache/sling/cli/impl/http/HttpClientFactoryTest.java
+++ b/src/test/java/org/apache/sling/cli/impl/http/HttpClientFactoryTest.java
@@ -1,0 +1,84 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package org.apache.sling.cli.impl.http;
+
+import java.net.InetSocketAddress;
+
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.sling.cli.impl.CredentialsService;
+import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.sun.net.httpserver.HttpContext;
+import com.sun.net.httpserver.HttpServer;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class HttpClientFactoryTest {
+
+    private HttpServer server;
+
+    @Rule
+    public OsgiContext osgiContext = new OsgiContext();
+
+    @Before
+    public void before() throws Throwable {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        HttpContext rootContext = server.createContext("/");
+        rootContext.setHandler(ex -> {
+            ex.sendResponseHeaders(401, -1);
+            ex.close();
+        });
+        server.start();
+        System.setProperty("asf.username", "asf.username");
+        System.setProperty("asf.password", "asf.password");
+        System.setProperty("jira.username", "jira.username");
+        System.setProperty("jira.password", "jira.password");
+        osgiContext.registerInjectActivateService(new CredentialsService());
+        osgiContext.registerInjectActivateService(new HttpClientFactory());
+    }
+
+    @Test
+    public void test401() {
+        HttpClientFactory factory = osgiContext.getService(HttpClientFactory.class);
+        if (factory == null) {
+            throw new IllegalStateException("Unable to retrieve an HttpClientFactory.");
+        }
+        CloseableHttpClient client = factory.newClient();
+        HttpGet httpGet = new HttpGet("http://" + server.getAddress().getHostString() + ":" + server.getAddress().getPort());
+        Throwable t = null;
+        try {
+            client.execute(httpGet);
+        } catch (Exception e) {
+            t = e;
+        }
+        assertNotNull(t);
+        assertTrue(t.getMessage().contains("Please check your authentication details"));
+    }
+
+    @After
+    public void after() {
+        server.stop(0);
+    }
+}


### PR DESCRIPTION
* added a response interceptor which throws an ISE when a server returns a 401 status code