### PR TITLE
SLING-11426 - The apache/sling-cli Docker image cannot be built on M1 processors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 # ----------------------------------------------------------------------------------------
-FROM eclipse-temurin:11-alpine as builder
+FROM azul/zulu-openjdk-alpine:17 as builder
+RUN apk add --no-cache binutils
 RUN $JAVA_HOME/bin/jlink --add-modules java.logging,java.naming,java.xml,java.security.jgss,java.sql,jdk.crypto.ec,java.desktop  --output /opt/jre --strip-debug --compress=2 --no-header-files --no-man-pages
 
 FROM alpine

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.37.0</version>
+                <version>0.40.1</version>
                 <executions>
                     <execution>
                         <id>default</id>


### PR DESCRIPTION
* updated the docker-maven-plugin to latest (0.40.1)
* switched to JDK 17 from Azul (this also works fine on M1 in comparison with the images that provide JDK 11), since it offers all architectures we need

This PR reverts the switch to Temurin from #12, since Temurin doesn't offer an arm64v8 image unless one uses the specific architecture repository. This would lead to profiles that would use different images based on host architecture.