### PR TITLE
SLING-11539 - update-local-site fails on arm64v8 with Java 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,18 +26,19 @@ COPY --from=builder /opt/jre /opt/jre
 RUN /opt/jre/bin/java -Xshare:dump
 
 # escaping required to properly handle arguments with spaces
-ENTRYPOINT ["/usr/share/sling-cli/bin/launcher.sh"]
+ENTRYPOINT ["/usr/share/sling-cli/bin/run.sh"]
+CMD ["help"]
 
 # Add feature launcher
-ADD target/lib /usr/share/sling-cli/launcher
+COPY target/lib/feature-launcher /usr/share/sling-cli/launcher
 # Add launcher script
-ADD target/classes/scripts /usr/share/sling-cli/bin
+COPY target/classes/scripts/run.sh /usr/share/sling-cli/bin/run.sh
 # workaround for MRESOURCES-236
 RUN chmod a+x /usr/share/sling-cli/bin/*
 # Add config files
-ADD target/classes/conf /usr/share/sling-cli/conf
+COPY target/classes/conf /usr/share/sling-cli/conf
 # Add all bundles
-ADD target/artifacts /usr/share/sling-cli/artifacts
+COPY target/artifacts /usr/share/sling-cli/artifacts
 # Add the service itself
 ARG FEATURE_FILE
-ADD ${FEATURE_FILE} /usr/share/sling-cli/sling-cli.feature
+COPY ${FEATURE_FILE} /usr/share/sling-cli/sling-cli.feature

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,30 @@
                             <overWriteReleases>false</overWriteReleases>
                             <includeScope>runtime</includeScope>
                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                            <stripVersion>true</stripVersion>
+                            <excludeTransitive>true</excludeTransitive>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-feature-launcher</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.sling</groupId>
+                                    <artifactId>org.apache.sling.feature.launcher</artifactId>
+                                    <type>zip</type>
+                                    <outputDirectory>${project.build.directory}/lib/feature-launcher</outputDirectory>
+                                    <fileMappers>
+                                        <org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                            <pattern>^org\.apache\.sling\.feature\.launcher-[0-9\.]+(-SNAPSHOT)?/</pattern>
+                                            <replacement>./</replacement>
+                                        </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                    </fileMappers>
+                                </artifactItem>
+                            </artifactItems>
                         </configuration>
                     </execution>
                 </executions>
@@ -113,30 +136,6 @@
                         <goals>
                             <goal>repository</goal>
                         </goals>
-                    </execution>
-                    <execution>
-                        <id>extra-dependencies</id>
-                        <goals>
-                            <goal>repository</goal>
-                        </goals>
-                        <configuration>
-                            <repositories>
-                                <repository>
-                                    <embedArtifacts>
-                                        <embedArtifact>
-                                            <groupId>org.apache.felix</groupId>
-                                            <artifactId>org.apache.felix.framework</artifactId>
-                                            <version>6.0.2</version>
-                                        </embedArtifact>
-                                        <embedArtifact>
-                                            <groupId>org.apache.sling</groupId>
-                                            <artifactId>org.apache.sling.launchpad.api</artifactId>
-                                            <version>1.2.0</version>
-                                        </embedArtifact>
-                                    </embedArtifacts>
-                                </repository>
-                            </repositories>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -223,7 +222,8 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.feature.launcher</artifactId>
-            <version>0.8.0</version>
+            <version>1.2.0</version>
+            <type>zip</type>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/src/main/features/app.json
+++ b/src/main/features/app.json
@@ -1,5 +1,10 @@
 {
     "id"     : "${project.groupId}:${project.artifactId}:slingfeature:app:${project.version}",
+    "execution-environment:JSON|false":{
+        "framework":{
+          "id":"org.apache.felix:org.apache.felix.framework:7.0.5"
+        }
+    },
     "bundles": [
         {
             "id"         : "${project.groupId}:${project.artifactId}:${project.version}",

--- a/src/main/resources/scripts/run.sh
+++ b/src/main/resources/scripts/run.sh
@@ -18,15 +18,16 @@
 ARGS_PROP="exec.args=$@"
 
 # Use exec to become pid 1, see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
-exec /opt/jre/bin/java \
+export JAVA_HOME=/opt/jre
+export JAVA_OPTS="\
+    -Dorg.slf4j.simpleLogger.logFile=/dev/null \
+    -Dlogback.configurationFile=file:/usr/share/sling-cli/conf/logback-default.xml \
     --add-opens=java.base/java.lang=ALL-UNNAMED \
     --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED \
     --add-opens=java.base/java.net=ALL-UNNAMED \
     --add-opens=java.base/java.security=ALL-UNNAMED \
-    -Xshare:on \
-    -Dorg.slf4j.simpleLogger.logFile=/dev/null \
-    -Dlogback.configurationFile=file:/usr/share/sling-cli/conf/logback-default.xml \
-    -jar /usr/share/sling-cli/launcher/org.apache.sling.feature.launcher.jar \
+    -Xshare:on"
+exec /usr/share/sling-cli/launcher/bin/launcher \
     -f /usr/share/sling-cli/sling-cli.feature \
     -c /usr/share/sling-cli/artifacts \
     -D "$ARGS_PROP" \


### PR DESCRIPTION
* updated to latest `org.apache.sling.feature.launcher` and `org.apache.felix.framework`
* optimised some pom configs
* renamed `launcher.sh` to `run.sh`, to make it less confusing, since we're now using the launcher distribution, rather than the jar