### PR TITLE
SLING-12140 - Creating new jira version fails: No releases found in 'Parent 60 (Java 11)'

### DIFF
--- a/src/main/java/org/apache/sling/cli/impl/jira/VersionClient.java
+++ b/src/main/java/org/apache/sling/cli/impl/jira/VersionClient.java
@@ -110,7 +110,7 @@ public class VersionClient {
 
     /**
      * Finds a version that is the successor of the version of the specified
-     * <tt>release</tt>
+     * <code>release</code>
      * 
      * <p>
      * A successor has the same base name but a higher version. For instance, the

--- a/src/main/java/org/apache/sling/cli/impl/release/Release.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/Release.java
@@ -32,9 +32,10 @@ public final class Release {
         Group 2: Release component
         Group 3: Release version
         Group 4: RC status (optional)
+        Group 5: Additional comment, e.g. (Java 11) (optional)
      */
     private static final Pattern RELEASE_PATTERN = Pattern.compile("^\\h*(Apache Sling\\h*)?([()a-zA-Z0-9\\-.\\h]+)\\h([0-9\\-.]+)" +
-            "\\h?(RC[0-9.]*)?\\h*$");
+            "\\h?(RC[0-9.]*)?\\h*(\\([a-zA-Z0-9\\s]+\\))?\\h*$");
     
     public static List<Release> fromString(String repositoryDescription) {
 
@@ -52,6 +53,9 @@ public final class Release {
                     fullName.append(matcher.group(1).trim()).append(" ");
                 }
                 fullName.append(rel.name);
+                if ( matcher.group(5) != null ) {
+                    fullName.append(' ').append(matcher.group(5));
+                }
                 rel.fullName = fullName.toString();
                 
                 releases.add(rel);
@@ -68,6 +72,7 @@ public final class Release {
     private String name;
     private String component;
     private String version;
+    private String comment;
 
     private Release() {
         
@@ -107,6 +112,14 @@ public final class Release {
      */
     public String getComponent() {
         return component;
+    }
+    
+    /**
+     * Returns the comment, e.g. <tt>(Java 11)</tt>
+     * @return the comment
+     */
+    public String getComment() {
+        return comment;
     }
 
     /**

--- a/src/main/java/org/apache/sling/cli/impl/release/Release.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/Release.java
@@ -106,7 +106,7 @@ public final class Release {
     }
 
     /**
-     * Returns the component, e.g. <tt>Foo</tt>
+     * Returns the component, e.g. <code>Foo</code>
      * 
      * @return the component
      */
@@ -115,7 +115,7 @@ public final class Release {
     }
     
     /**
-     * Returns the comment, e.g. <tt>(Java 11)</tt>
+     * Returns the comment, e.g. <code>(Java 11)</code>
      * @return the comment
      */
     public String getComment() {
@@ -125,10 +125,10 @@ public final class Release {
     /**
      * Creates a new Release object that corresponds to the next release name
      * 
-     * <p>The next object is identical to <tt>this</tt> object, except the fact that the
+     * <p>The next object is identical to <code>this</code> object, except the fact that the
      * micro component of the version is increased by two.</P>
      * 
-     * <p>For instance, the next version of <tt>Apache Sling Foo 1.0.2</tt> is <tt>Apache Sling Foo 1.0.4</tt>.</p>
+     * <p>For instance, the next version of <code>Apache Sling Foo 1.0.2</code> is <code>Apache Sling Foo 1.0.4</code>.</p>
      * 
      * @return the next release
      */

--- a/src/test/java/org/apache/sling/cli/impl/release/ReleaseTest.java
+++ b/src/test/java/org/apache/sling/cli/impl/release/ReleaseTest.java
@@ -16,16 +16,16 @@
  */
 package org.apache.sling.cli.impl.release;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
@@ -104,6 +104,15 @@ public class ReleaseTest {
         Release next = release.next();
         
         assertEquals("Apache Sling Bar 3", next.getFullName());
+    }
+    
+    @Test
+    public void releaseWithJavaInfo() {
+        List<Release> releases = Release.fromString("Parent 60 (Java 11)");
+        
+        assertEquals("releases.size", 1, releases.size());
+        assertEquals("release.fullName", "Parent 60 (Java 11)", releases.get(0).getFullName());
+        
     }
 
 }


### PR DESCRIPTION
Support optional comments in the Release