### PR TITLE
SLING-12146 - Committer CLI build fails on Windows

### DIFF
--- a/.sling-module.json
+++ b/.sling-module.json
@@ -1,5 +1,8 @@
 {
     "jenkins": {
-        "jdks": [11]
+        "jdks": [11],
+        "operatingSystems": [
+            "linux"
+        ]
     }
 }


### PR DESCRIPTION
Restrict builds to Linux until we get the Windows build passing.