### PR TITLE
SLING-12148 - Fixing CI Validation Failure 

### DIFF
--- a/src/main/java/org/apache/sling/cli/impl/ci/CIStatusValidator.java
+++ b/src/main/java/org/apache/sling/cli/impl/ci/CIStatusValidator.java
@@ -139,8 +139,9 @@ public class CIStatusValidator {
         if (ciEndpoint == null) {
             return new ValidationResult(false, "Cannot extract a CI endpoint from " + artifactFilePath.getFileName());
         }
+        JsonObject status = null;
         try {
-            JsonObject status = fetchJson(ciEndpoint);
+            status = fetchJson(ciEndpoint);
 
             if ("pending".equals(status.get(PN_STATE).getAsString())
                     && status.get("statuses").getAsJsonArray().size() == 0) {
@@ -173,7 +174,8 @@ public class CIStatusValidator {
                 return new ValidationResult(false, message);
             }
         } catch (UnsupportedOperationException | IOException e) {
-            return new ValidationResult(false, "Failed to get CI Status: " + e.toString());
+            return new ValidationResult(false,
+                    "Failed to get CI Status: " + e.toString() + "\nUrl: " + ciEndpoint + "\nStatus Body: " + status);
         }
     }
 

--- a/src/main/java/org/apache/sling/cli/impl/ci/CIStatusValidator.java
+++ b/src/main/java/org/apache/sling/cli/impl/ci/CIStatusValidator.java
@@ -179,7 +179,7 @@ public class CIStatusValidator {
             }
         } catch (Exception e) {
             return new ValidationResult(false,
-                    "Failed to get CI Status: " + e.toString() + "\nUrl: " + ciEndpoint + "\nStatus Body: " + status);
+                    "Failed to get CI Status: " + e.toString() + "\nCI Status Url: " + ciEndpoint + "\nCI Status Body: " + status);
         }
     }
 

--- a/src/main/java/org/apache/sling/cli/impl/ci/CIStatusValidator.java
+++ b/src/main/java/org/apache/sling/cli/impl/ci/CIStatusValidator.java
@@ -120,6 +120,10 @@ public class CIStatusValidator {
                         repositoryName = repositoryName.substring(0, repositoryName.indexOf('/'));
                     }
                 }
+                // strip off the .git suffix from the repo name if it exists
+                if(repositoryName.endsWith(".git")) {
+                    repositoryName = repositoryName.substring(0, repositoryName.length() - 4);
+                }
                 log.debug("Extracted REPO: {}", repositoryName);
             }
             if (repositoryName != null && !repositoryName.isEmpty() && !tagName.isEmpty() && !tagName.equalsIgnoreCase("HEAD")) {

--- a/src/main/java/org/apache/sling/cli/impl/ci/CIStatusValidator.java
+++ b/src/main/java/org/apache/sling/cli/impl/ci/CIStatusValidator.java
@@ -173,7 +173,7 @@ public class CIStatusValidator {
             } else {
                 return new ValidationResult(false, message);
             }
-        } catch (UnsupportedOperationException | IOException e) {
+        } catch (Exception e) {
             return new ValidationResult(false,
                     "Failed to get CI Status: " + e.toString() + "\nUrl: " + ciEndpoint + "\nStatus Body: " + status);
         }

--- a/src/test/java/org/apache/sling/cli/impl/ci/CIStatusValidatorTest.java
+++ b/src/test/java/org/apache/sling/cli/impl/ci/CIStatusValidatorTest.java
@@ -146,4 +146,10 @@ public class CIStatusValidatorTest {
         assertNotNull(valid.getMessage());
     }
 
+    @Test
+    public void supportsGitHubUrls() throws URISyntaxException {
+        ValidationResult valid = validator.isValid(getResourcePath("/ci/gh-repo-1.0.pom"));
+        assertTrue(valid.isValid());
+        assertNotNull(valid.getMessage());
+    }
 }

--- a/src/test/resources/ci/gh-repo-1.0.pom
+++ b/src/test/resources/ci/gh-repo-1.0.pom
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional 
+    information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except 
+    in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to 
+    in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See 
+    the License for the specific language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>sling-bundle-parent</artifactId>
+        <version>35</version>
+        <relativePath />
+    </parent>
+
+    <artifactId>repo-pom</artifactId>
+    <version>1.1</version>
+
+    <name>Repo POM</name>
+    <description>A Sample POM File with a repo</description>
+
+    <scm>
+        <connection>scm:git:https://gitbox.apache.org/repos/asf/sling-repo-pom.git</connection>
+        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/sling-repo-pom.git</developerConnection>
+        <url>https://github.com/apache/sling-repo-pom.git</url>
+        <tag>repo-pom-1.1</tag>
+    </scm>
+
+</project>


### PR DESCRIPTION
Strips out the .git suffix if the resolved repositoryName contains it which was leading to the status URL being incorrect.