### PR TITLE
SLING-13253 - release close-staging command

### DIFF
--- a/src/main/java/org/apache/sling/cli/impl/release/AbstractStagingRepositoryCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/AbstractStagingRepositoryCommand.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.cli.impl.release;
+
+import java.io.IOException;
+
+import org.apache.sling.cli.impl.Command;
+import org.apache.sling.cli.impl.InputOption;
+import org.apache.sling.cli.impl.UserInput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+/**
+ * Base for the staging-repository commands (close-staging, promote, drop). They all take a repository
+ * id, resolve a target from it and then act on that target according to the CLI execution mode. This
+ * class owns the shared CLI options and the execution-mode dispatch, leaving each command to declare
+ * its own {@code RepositoryService} reference (kept in the concrete class so Declarative Services
+ * generates the component descriptor) and to provide its command-specific behaviour.
+ *
+ * @param <T> the resolved target the command operates on (a repository, or a small context holding the
+ *            repository together with derived display information)
+ */
+abstract class AbstractStagingRepositoryCommand<T> implements Command {
+
+    @CommandLine.Option(
+            names = {"-r", "--repository"},
+            description = "Nexus staging repository id",
+            required = true)
+    protected Integer repositoryId;
+
+    @CommandLine.Mixin
+    protected ReusableCLIOptions reusableCLIOptions;
+
+    @Override
+    public final Integer call() {
+        Logger logger = LoggerFactory.getLogger(getClass());
+        try {
+            T target = resolve();
+            switch (reusableCLIOptions.executionMode) {
+                case DRY_RUN:
+                    logger.info(dryRunMessage(target));
+                    break;
+                case INTERACTIVE:
+                    if (InputOption.YES.equals(UserInput.yesNo(confirmationQuestion(target), interactiveDefault()))) {
+                        perform(target);
+                    } else {
+                        logger.info("Aborted.");
+                    }
+                    break;
+                case AUTO:
+                    perform(target);
+                    break;
+            }
+        } catch (IOException e) {
+            logger.warn("Failed executing command", e);
+            return CommandLine.ExitCode.SOFTWARE;
+        }
+        return CommandLine.ExitCode.OK;
+    }
+
+    /** Resolves the target this command acts on from {@link #repositoryId}. */
+    protected abstract T resolve() throws IOException;
+
+    /** The message logged in dry-run mode. */
+    protected abstract String dryRunMessage(T target);
+
+    /** The yes/no question asked in interactive mode. */
+    protected abstract String confirmationQuestion(T target);
+
+    /** Performs the actual state-changing operation. */
+    protected abstract void perform(T target) throws IOException;
+
+    /** The pre-selected option for the interactive confirmation; defaults to {@link InputOption#YES}. */
+    protected InputOption interactiveDefault() {
+        return InputOption.YES;
+    }
+}

--- a/src/main/java/org/apache/sling/cli/impl/release/CloseStagingCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/CloseStagingCommand.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.cli.impl.release;
+
+import java.io.IOException;
+import java.util.stream.Collectors;
+
+import org.apache.sling.cli.impl.Command;
+import org.apache.sling.cli.impl.nexus.RepositoryService;
+import org.apache.sling.cli.impl.nexus.StagingRepository;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+@Component(
+        service = Command.class,
+        property = {
+            Command.PROPERTY_NAME_COMMAND_GROUP + "=" + CloseStagingCommand.GROUP,
+            Command.PROPERTY_NAME_COMMAND_NAME + "=" + CloseStagingCommand.NAME
+        })
+@CommandLine.Command(
+        name = CloseStagingCommand.NAME,
+        description =
+                "Closes an open Nexus staging repository after 'mvn release:perform', making it ready for verification and voting",
+        subcommands = CommandLine.HelpCommand.class)
+public class CloseStagingCommand extends AbstractStagingRepositoryCommand<CloseStagingCommand.Target> {
+
+    static final String GROUP = "release";
+    static final String NAME = "close-staging";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloseStagingCommand.class);
+
+    @Reference
+    private RepositoryService repositoryService;
+
+    @Override
+    protected Target resolve() throws IOException {
+        StagingRepository repository = repositoryService.findAny(repositoryId);
+        // Derive the description from the staged artifacts' POM (name + version), since releases staged
+        // via the plain maven-deploy-plugin only get the generic Nexus "Implicitly created (auto
+        // staging)" description. The repository is still open at this point, so it is not in the Lucene
+        // index yet; browse its content directly.
+        String description = repositoryService.getReleasesFromContent(repository).stream()
+                .map(Release::getFullName)
+                .collect(Collectors.joining(", "));
+        if (description.isEmpty()) {
+            description = repository.getDescription();
+        }
+        return new Target(repository, description);
+    }
+
+    @Override
+    protected String dryRunMessage(Target target) {
+        return String.format(
+                "Would close staging repository %s with description \"%s\".",
+                target.repository.getRepositoryId(), target.description);
+    }
+
+    @Override
+    protected String confirmationQuestion(Target target) {
+        return String.format(
+                "Close staging repository %s with description \"%s\"?",
+                target.repository.getRepositoryId(), target.description);
+    }
+
+    @Override
+    protected void perform(Target target) throws IOException {
+        LOGGER.info(
+                "Closing staging repository {} with description \"{}\"...",
+                target.repository.getRepositoryId(),
+                target.description);
+        repositoryService.close(target.repository, target.description);
+        LOGGER.info(
+                "Done. Repository {} is now closed and ready for verification and voting.",
+                target.repository.getRepositoryId());
+    }
+
+    static final class Target {
+        private final StagingRepository repository;
+        private final String description;
+
+        Target(StagingRepository repository, String description) {
+            this.repository = repository;
+            this.description = description;
+        }
+    }
+}

--- a/src/test/java/org/apache/sling/cli/impl/release/CloseStagingCommandTest.java
+++ b/src/test/java/org/apache/sling/cli/impl/release/CloseStagingCommandTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.cli.impl.release;
+
+import java.util.Set;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.sling.cli.impl.Command;
+import org.apache.sling.cli.impl.ExecutionMode;
+import org.apache.sling.cli.impl.InputOption;
+import org.apache.sling.cli.impl.UserInput;
+import org.apache.sling.cli.impl.junit.LogCapture;
+import org.apache.sling.cli.impl.nexus.RepositoryService;
+import org.apache.sling.cli.impl.nexus.StagingRepository;
+import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import picocli.CommandLine;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CloseStagingCommandTest {
+
+    @Rule
+    public final OsgiContext osgiContext = new OsgiContext();
+
+    @Rule
+    public final LogCapture logCapture = new LogCapture(CloseStagingCommand.class);
+
+    private RepositoryService repositoryService;
+    private StagingRepository stagingRepository;
+
+    @Before
+    public void before() throws Exception {
+        stagingRepository = mock(StagingRepository.class);
+        when(stagingRepository.getRepositoryId()).thenReturn("orgapachesling-123");
+        when(stagingRepository.getDescription()).thenReturn("Apache Sling CLI Test 1.0.0");
+
+        repositoryService = mock(RepositoryService.class);
+        when(repositoryService.findAny(123)).thenReturn(stagingRepository);
+        Set<Release> releases =
+                Set.of(Release.fromString("Apache Sling CLI Test 1.0.0").get(0));
+        when(repositoryService.getReleasesFromContent(stagingRepository)).thenReturn(releases);
+
+        osgiContext.registerService(RepositoryService.class, repositoryService);
+    }
+
+    @Test
+    public void testDryRun() throws Exception {
+        Command command = createCommand(123, ExecutionMode.DRY_RUN);
+        assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+        assertTrue(logCapture.containsMessage(
+                "Would close staging repository orgapachesling-123 with description \"Apache Sling CLI Test 1.0.0\"."));
+        verify(repositoryService, never()).close(any(), any());
+    }
+
+    @Test
+    public void testInteractiveYes() throws Exception {
+        try (MockedStatic<UserInput> userInputMock = mockStatic(UserInput.class)) {
+            String question =
+                    "Close staging repository orgapachesling-123 with description \"Apache Sling CLI Test 1.0.0\"?";
+            userInputMock.when(() -> UserInput.yesNo(question, InputOption.YES)).thenReturn(InputOption.YES);
+            Command command = createCommand(123, ExecutionMode.INTERACTIVE);
+            assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+            verify(repositoryService).close(stagingRepository, "Apache Sling CLI Test 1.0.0");
+        }
+    }
+
+    @Test
+    public void testAuto() throws Exception {
+        Command command = createCommand(123, ExecutionMode.AUTO);
+        assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+        verify(repositoryService, times(1)).close(stagingRepository, "Apache Sling CLI Test 1.0.0");
+    }
+
+    @Test
+    public void testInteractiveNoAborts() throws Exception {
+        try (MockedStatic<UserInput> userInputMock = mockStatic(UserInput.class)) {
+            userInputMock.when(() -> UserInput.yesNo(any(), any())).thenReturn(InputOption.NO);
+            Command command = createCommand(123, ExecutionMode.INTERACTIVE);
+            assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+            assertTrue(logCapture.containsMessage("Aborted."));
+            verify(repositoryService, never()).close(any(), any());
+        }
+    }
+
+    @Test
+    public void testDescriptionFallsBackToRepositoryDescription() throws Exception {
+        // no releases can be derived from the (still open) repository content: fall back to the
+        // repository's own description
+        when(repositoryService.getReleasesFromContent(stagingRepository)).thenReturn(Set.of());
+        Command command = createCommand(123, ExecutionMode.AUTO);
+        assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+        verify(repositoryService).close(stagingRepository, "Apache Sling CLI Test 1.0.0");
+    }
+
+    @Test
+    public void testIOExceptionReturnsSoftware() throws Exception {
+        when(repositoryService.findAny(123)).thenThrow(new java.io.IOException("nexus down"));
+        Command command = createCommand(123, ExecutionMode.AUTO);
+        assertEquals(CommandLine.ExitCode.SOFTWARE, (int) command.call());
+        assertTrue(logCapture.containsMessage("Failed executing command"));
+    }
+
+    private Command createCommand(int repositoryId, ExecutionMode executionMode) throws IllegalAccessException {
+        CloseStagingCommand closeStagingCommand = spy(new CloseStagingCommand());
+        FieldUtils.writeField(closeStagingCommand, "repositoryId", repositoryId, true);
+        ReusableCLIOptions reusableCLIOptions = mock(ReusableCLIOptions.class);
+        FieldUtils.writeField(reusableCLIOptions, "executionMode", executionMode, true);
+        FieldUtils.writeField(closeStagingCommand, "reusableCLIOptions", reusableCLIOptions, true);
+        osgiContext.registerInjectActivateService(closeStagingCommand);
+        Command result = osgiContext.getService(Command.class);
+        assertTrue(
+                "Expected to retrieve the CloseStagingCommand from the mocked OSGi environment.",
+                result instanceof CloseStagingCommand);
+        return result;
+    }
+}


### PR DESCRIPTION
Part of splitting #28 into per-command changes.

**Jira:** https://issues.apache.org/jira/browse/SLING-13253

Adds `release close-staging` to close an open Nexus staging repository after `mvn release:perform`, making it ready for verification and voting.

Stacked on #29; please merge that first.

---
**Stack (merge in order):** #29 list → #30 close-staging → #31 promote/drop → #32 update-dist → #33 tally-votes → #34 finalize