### PR TITLE
SLING-13253 - release promote and drop staging repository commands

### DIFF
--- a/src/main/java/org/apache/sling/cli/impl/release/DropCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/DropCommand.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.cli.impl.release;
+
+import java.io.IOException;
+
+import org.apache.sling.cli.impl.Command;
+import org.apache.sling.cli.impl.InputOption;
+import org.apache.sling.cli.impl.nexus.RepositoryService;
+import org.apache.sling.cli.impl.nexus.StagingRepository;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+@Component(
+        service = Command.class,
+        property = {
+            Command.PROPERTY_NAME_COMMAND_GROUP + "=" + DropCommand.GROUP,
+            Command.PROPERTY_NAME_COMMAND_NAME + "=" + DropCommand.NAME
+        })
+@CommandLine.Command(
+        name = DropCommand.NAME,
+        description = "Drops a Nexus staging repository. Use when a vote fails or to clean up a failed release.",
+        subcommands = CommandLine.HelpCommand.class)
+public class DropCommand extends AbstractStagingRepositoryCommand<StagingRepository> {
+
+    static final String GROUP = "release";
+    static final String NAME = "drop";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DropCommand.class);
+
+    @Reference
+    private RepositoryService repositoryService;
+
+    @Override
+    protected StagingRepository resolve() throws IOException {
+        return repositoryService.findAny(repositoryId);
+    }
+
+    @Override
+    protected String dryRunMessage(StagingRepository repository) {
+        return String.format(
+                "Would drop staging repository %s: %s", repository.getRepositoryId(), repository.getDescription());
+    }
+
+    @Override
+    protected String confirmationQuestion(StagingRepository repository) {
+        return String.format(
+                "Drop staging repository %s (%s)? This cannot be undone.",
+                repository.getRepositoryId(), repository.getDescription());
+    }
+
+    @Override
+    protected InputOption interactiveDefault() {
+        return InputOption.NO;
+    }
+
+    @Override
+    protected void perform(StagingRepository repository) throws IOException {
+        LOGGER.info("Dropping staging repository {}...", repository.getRepositoryId());
+        repositoryService.drop(repository);
+        LOGGER.info("Done. Repository {} has been dropped.", repository.getRepositoryId());
+    }
+}

--- a/src/main/java/org/apache/sling/cli/impl/release/PromoteCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/PromoteCommand.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.cli.impl.release;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.sling.cli.impl.Command;
+import org.apache.sling.cli.impl.nexus.RepositoryService;
+import org.apache.sling.cli.impl.nexus.StagingRepository;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+@Component(
+        service = Command.class,
+        property = {
+            Command.PROPERTY_NAME_COMMAND_GROUP + "=" + PromoteCommand.GROUP,
+            Command.PROPERTY_NAME_COMMAND_NAME + "=" + PromoteCommand.NAME
+        })
+@CommandLine.Command(
+        name = PromoteCommand.NAME,
+        description = "Promotes a closed Nexus staging repository to Maven Central after a successful vote",
+        subcommands = CommandLine.HelpCommand.class)
+public class PromoteCommand extends AbstractStagingRepositoryCommand<PromoteCommand.Target> {
+
+    static final String GROUP = "release";
+    static final String NAME = "promote";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PromoteCommand.class);
+
+    @Reference
+    private RepositoryService repositoryService;
+
+    @Override
+    protected Target resolve() throws IOException {
+        StagingRepository repository = repositoryService.find(repositoryId);
+        Set<Release> releases = repositoryService.getReleases(repository);
+        String releaseNames = releases.stream().map(Release::getFullName).collect(Collectors.joining(", "));
+        return new Target(repository, releaseNames);
+    }
+
+    @Override
+    protected String dryRunMessage(Target target) {
+        return String.format(
+                "Would promote %s to Maven Central from repository %s",
+                target.releaseNames, target.repository.getRepositoryId());
+    }
+
+    @Override
+    protected String confirmationQuestion(Target target) {
+        return String.format("Promote %s to Maven Central?", target.releaseNames);
+    }
+
+    @Override
+    protected void perform(Target target) throws IOException {
+        LOGGER.info("Promoting {} to Maven Central...", target.releaseNames);
+        repositoryService.promote(target.repository);
+        LOGGER.info("Done. Artifacts will appear on Maven Central within ~10 minutes.");
+    }
+
+    static final class Target {
+        private final StagingRepository repository;
+        private final String releaseNames;
+
+        Target(StagingRepository repository, String releaseNames) {
+            this.repository = repository;
+            this.releaseNames = releaseNames;
+        }
+    }
+}

--- a/src/test/java/org/apache/sling/cli/impl/release/DropCommandTest.java
+++ b/src/test/java/org/apache/sling/cli/impl/release/DropCommandTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.cli.impl.release;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.sling.cli.impl.Command;
+import org.apache.sling.cli.impl.ExecutionMode;
+import org.apache.sling.cli.impl.InputOption;
+import org.apache.sling.cli.impl.UserInput;
+import org.apache.sling.cli.impl.junit.LogCapture;
+import org.apache.sling.cli.impl.nexus.RepositoryService;
+import org.apache.sling.cli.impl.nexus.StagingRepository;
+import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import picocli.CommandLine;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DropCommandTest {
+
+    @Rule
+    public final OsgiContext osgiContext = new OsgiContext();
+
+    @Rule
+    public final LogCapture logCapture = new LogCapture(DropCommand.class);
+
+    private RepositoryService repositoryService;
+    private StagingRepository stagingRepository;
+
+    @Before
+    public void before() throws Exception {
+        stagingRepository = mock(StagingRepository.class);
+        when(stagingRepository.getRepositoryId()).thenReturn("orgapachesling-123");
+        when(stagingRepository.getDescription()).thenReturn("Apache Sling CLI Test 1.0.0");
+
+        repositoryService = mock(RepositoryService.class);
+        when(repositoryService.findAny(123)).thenReturn(stagingRepository);
+
+        osgiContext.registerService(RepositoryService.class, repositoryService);
+    }
+
+    @Test
+    public void testDryRun() throws Exception {
+        Command command = createCommand(123, ExecutionMode.DRY_RUN);
+        assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+        verify(repositoryService, never()).drop(any());
+        assertTrue(logCapture.containsMessage("Would drop staging repository"));
+    }
+
+    @Test
+    public void testInteractiveYes() throws Exception {
+        try (MockedStatic<UserInput> userInputMock = mockStatic(UserInput.class)) {
+            userInputMock.when(() -> UserInput.yesNo(anyString(), any())).thenReturn(InputOption.YES);
+            Command command = createCommand(123, ExecutionMode.INTERACTIVE);
+            assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+            verify(repositoryService, times(1)).drop(stagingRepository);
+        }
+    }
+
+    @Test
+    public void testInteractiveNo() throws Exception {
+        try (MockedStatic<UserInput> userInputMock = mockStatic(UserInput.class)) {
+            userInputMock.when(() -> UserInput.yesNo(anyString(), any())).thenReturn(InputOption.NO);
+            Command command = createCommand(123, ExecutionMode.INTERACTIVE);
+            assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+            verify(repositoryService, never()).drop(any());
+            assertTrue(logCapture.containsMessage("Aborted."));
+        }
+    }
+
+    @Test
+    public void testAuto() throws Exception {
+        Command command = createCommand(123, ExecutionMode.AUTO);
+        assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+        verify(repositoryService, times(1)).drop(stagingRepository);
+    }
+
+    private Command createCommand(int repositoryId, ExecutionMode executionMode) throws IllegalAccessException {
+        DropCommand dropCommand = spy(new DropCommand());
+        FieldUtils.writeField(dropCommand, "repositoryId", repositoryId, true);
+        ReusableCLIOptions reusableCLIOptions = mock(ReusableCLIOptions.class);
+        FieldUtils.writeField(reusableCLIOptions, "executionMode", executionMode, true);
+        FieldUtils.writeField(dropCommand, "reusableCLIOptions", reusableCLIOptions, true);
+        osgiContext.registerInjectActivateService(dropCommand);
+        Command result = osgiContext.getService(Command.class);
+        assertTrue(
+                "Expected to retrieve the DropCommand from the mocked OSGi environment.",
+                result instanceof DropCommand);
+        return result;
+    }
+}

--- a/src/test/java/org/apache/sling/cli/impl/release/PromoteCommandTest.java
+++ b/src/test/java/org/apache/sling/cli/impl/release/PromoteCommandTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.cli.impl.release;
+
+import java.util.Set;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.sling.cli.impl.Command;
+import org.apache.sling.cli.impl.ExecutionMode;
+import org.apache.sling.cli.impl.InputOption;
+import org.apache.sling.cli.impl.UserInput;
+import org.apache.sling.cli.impl.junit.LogCapture;
+import org.apache.sling.cli.impl.nexus.RepositoryService;
+import org.apache.sling.cli.impl.nexus.StagingRepository;
+import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import picocli.CommandLine;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class PromoteCommandTest {
+
+    @Rule
+    public final OsgiContext osgiContext = new OsgiContext();
+
+    @Rule
+    public final LogCapture logCapture = new LogCapture(PromoteCommand.class);
+
+    private RepositoryService repositoryService;
+    private StagingRepository stagingRepository;
+
+    @Before
+    public void before() throws Exception {
+        stagingRepository = mock(StagingRepository.class);
+        when(stagingRepository.getRepositoryId()).thenReturn("orgapachesling-123");
+
+        repositoryService = mock(RepositoryService.class);
+        when(repositoryService.find(123)).thenReturn(stagingRepository);
+        Set<Release> releases =
+                Set.of(Release.fromString("Apache Sling CLI Test 1.0.0").get(0));
+        when(repositoryService.getReleases(stagingRepository)).thenReturn(releases);
+
+        osgiContext.registerService(RepositoryService.class, repositoryService);
+    }
+
+    @Test
+    public void testDryRun() throws Exception {
+        Command command = createCommand(123, ExecutionMode.DRY_RUN);
+        assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+        verify(repositoryService, never()).promote(any());
+        assertTrue(logCapture.containsMessage("Would promote"));
+    }
+
+    @Test
+    public void testInteractiveYes() throws Exception {
+        try (MockedStatic<UserInput> userInputMock = mockStatic(UserInput.class)) {
+            userInputMock.when(() -> UserInput.yesNo(anyString(), any())).thenReturn(InputOption.YES);
+            Command command = createCommand(123, ExecutionMode.INTERACTIVE);
+            assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+            verify(repositoryService, times(1)).promote(stagingRepository);
+        }
+    }
+
+    @Test
+    public void testAuto() throws Exception {
+        Command command = createCommand(123, ExecutionMode.AUTO);
+        assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+        verify(repositoryService, times(1)).promote(stagingRepository);
+    }
+
+    private Command createCommand(int repositoryId, ExecutionMode executionMode) throws IllegalAccessException {
+        PromoteCommand promoteCommand = spy(new PromoteCommand());
+        FieldUtils.writeField(promoteCommand, "repositoryId", repositoryId, true);
+        ReusableCLIOptions reusableCLIOptions = mock(ReusableCLIOptions.class);
+        FieldUtils.writeField(reusableCLIOptions, "executionMode", executionMode, true);
+        FieldUtils.writeField(promoteCommand, "reusableCLIOptions", reusableCLIOptions, true);
+        osgiContext.registerInjectActivateService(promoteCommand);
+        Command result = osgiContext.getService(Command.class);
+        assertTrue(
+                "Expected to retrieve the PromoteCommand from the mocked OSGi environment.",
+                result instanceof PromoteCommand);
+        return result;
+    }
+}


### PR DESCRIPTION
Part of splitting #28 into per-command changes.

**Jira:** https://issues.apache.org/jira/browse/SLING-13253

Adds:
- `release promote` — promote a closed Nexus staging repository to Maven Central after a successful vote
- `release drop` — drop a staging repository when a vote fails or to clean up

Stacked on the close-staging PR.

---
**Stack (merge in order):** #29 list → #30 close-staging → #31 promote/drop → #32 update-dist → #33 tally-votes → #34 finalize