### PR TITLE
SLING-13253 - release tally-votes: PMC-aware result email

### DIFF
--- a/src/main/java/org/apache/sling/cli/impl/release/TallyVotesCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/TallyVotesCommand.java
@@ -139,6 +139,7 @@ public class TallyVotesCommand implements Command {
                         .replace("##DATE##", dateProvider.getCurrentDateForEmailHeader())
                         .replace("##RELEASE_NAME##", releaseFullName)
                         .replace("##BINDING_VOTERS##", String.join(", ", bindingVoters))
+                        .replace("##CLOSING_ACTION##", closingAction(releaseFullName, currentMember.isPMCMember()))
                         .replace(
                                 "##USER_NAME##",
                                 membersFinder.getCurrentMember().getName());
@@ -191,6 +192,23 @@ public class TallyVotesCommand implements Command {
             return CommandLine.ExitCode.SOFTWARE;
         }
         return CommandLine.ExitCode.OK;
+    }
+
+    /**
+     * Builds the closing paragraph of the result email. PMC members copy the release to the dist
+     * directory themselves; non-PMC release managers can only promote to Maven Central and must ask
+     * a PMC member to handle the dist upload (which is restricted to PMC members). PMC membership is
+     * derived from the current user, so no flag is needed.
+     */
+    private String closingAction(String releaseFullName, boolean isPmcMember) {
+        if (isPmcMember) {
+            return "I will copy this release to the Sling dist directory and\n"
+                    + "promote the artifacts to the central Maven repository.";
+        }
+        return "I will promote the artifacts to the central Maven repository.\n\n"
+                + "As I am not a PMC member, I cannot copy the release to the dist directory myself.\n\n"
+                + "ACTION NEEDED: can a PMC member please copy " + releaseFullName
+                + " to the Sling dist directory (https://dist.apache.org/repos/dist/release/sling/)?";
     }
 
     // TODO - better detection of '+1' votes

--- a/src/main/resources/templates/tally-votes.email
+++ b/src/main/resources/templates/tally-votes.email
@@ -11,8 +11,7 @@ The vote has passed with the following result:
 +1 (binding): ##BINDING_VOTERS##
 +1 (non-binding): ##NON_BINDING_VOTERS##
 
-I will copy this release to the Sling dist directory and
-promote the artifacts to the central Maven repository.
+##CLOSING_ACTION##
 
 Regards,
 ##USER_NAME##

--- a/src/test/java/org/apache/sling/cli/impl/release/TallyVotesCommandTest.java
+++ b/src/test/java/org/apache/sling/cli/impl/release/TallyVotesCommandTest.java
@@ -111,6 +111,49 @@ public class TallyVotesCommandTest {
     }
 
     @Test
+    public void testDryRunNonPmc() throws Exception {
+        // Daniel (a non-PMC committer) is the release manager running tally-votes; PMC status is
+        // auto-detected from the current user, so the result email asks a PMC member to do the dist
+        // upload.
+        Mailer mailer = mock(Mailer.class);
+        List<Email> thread = new ArrayList<>() {
+            {
+                add(mockEmail("daniel@apache.org", "Daniel"));
+                add(mockEmail("alice@apache.org", "Alice"));
+                add(mockEmail("bob@apache.org", "Bob"));
+                add(mockEmail("charlie@apache.org", "Charlie"));
+            }
+        };
+        prepareExecution(mailer, thread, "daniel");
+        Command command = createCommand(123, ExecutionMode.DRY_RUN);
+        assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+        verifyNoInteractions(mailer);
+        assertTrue(logCapture.containsMessage("""
+                From: Daniel <daniel@apache.org>
+                To: "Sling Developers List" <dev@sling.apache.org>
+                Reply-To: "Sling Developers List" <dev@sling.apache.org>
+                Date: Thu, 1 Jan 1970 01:00:00 +0100
+                Subject: [RESULT] [VOTE] Release Apache Sling CLI Test 1.0.0
+
+                Hi,
+
+                The vote has passed with the following result:
+
+                +1 (binding): Alice, Bob, Charlie
+                +1 (non-binding): none
+
+                I will promote the artifacts to the central Maven repository.
+
+                As I am not a PMC member, I cannot copy the release to the dist directory myself.
+
+                ACTION NEEDED: can a PMC member please copy Apache Sling CLI Test 1.0.0 to the Sling dist directory (https://dist.apache.org/repos/dist/release/sling/)?
+
+                Regards,
+                Daniel
+                """));
+    }
+
+    @Test
     public void testDryRunNotEnoughBindingVotes() throws Exception {
         Mailer mailer = mock(Mailer.class);
         List<Email> thread = new ArrayList<>() {
@@ -184,8 +227,13 @@ public class TallyVotesCommandTest {
     }
 
     private void prepareExecution(Mailer mailer, List<Email> thread) throws IOException, IllegalAccessException {
+        prepareExecution(mailer, thread, "johndoe");
+    }
+
+    private void prepareExecution(Mailer mailer, List<Email> thread, String currentUsername)
+            throws IOException, IllegalAccessException {
         CredentialsService credentialsService = mock(CredentialsService.class);
-        when(credentialsService.getAsfCredentials()).thenReturn(new Credentials("johndoe", "secret"));
+        when(credentialsService.getAsfCredentials()).thenReturn(new Credentials(currentUsername, "secret"));
 
         MembersFinder membersFinder = spy(new MembersFinder());
         Set<Member> members = new HashSet<>() {


### PR DESCRIPTION
Part of splitting #28 into per-command changes.

**Jira:** https://issues.apache.org/jira/browse/SLING-13253

Makes `release tally-votes` aware of PMC membership when counting binding vs non-binding votes and generating the result email.

Stacked on the update-dist PR.

---
**Stack (merge in order):** #29 list → #30 close-staging → #31 promote/drop → #32 update-dist → #33 tally-votes → #34 finalize