### PR TITLE
SLING-13253 - release finalize command and act-by-name support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,108 @@ This module is part of the [Apache Sling](https://sling.apache.org) project.
 This module provides a command-line tool which automates various Sling development tasks. The tool is packaged
 as a docker image.
 
-## Configuration
+## Prerequisites
 
-To make various credentials and configurations available to the docker image it is recommended to use a docker env file.
-A sample file is stored at `docker-env.sample`. Copy this file to `docker-env` and fill in your own information.
+Before releasing you need the following in place. These are split between the **Maven side** (used by
+`mvn release:prepare`/`release:perform` in the project being released) and the **CLI side** (used by
+this Docker tool).
+
+### 1. ASF credentials for the CLI (`docker-env`)
+
+To make credentials available to the docker image, use a docker env file. A sample file is stored at
+`docker-env.sample`; copy it to `docker-env` and fill in your own information. At minimum it must
+provide your ASF credentials (these are read by the CLI for Nexus, JIRA, Whimsy and the mailing
+lists):
+
+    ASF_USERNAME=your-apache-id
+    ASF_PASSWORD=your-apache-password
+
+### 2. GPG signing key
+
+* Generate a code-signing key and publish it: `gpg --send-keys <KEY_ID>` to `keys.openpgp.org`, and
+  add its public block to the Sling `KEYS` file at
+  <https://dist.apache.org/repos/dist/release/sling/KEYS> (PMC members can commit there directly).
+* Note the key id (e.g. `0A1B2C3D4E5F6789`) — it goes into `settings.xml` below.
+
+### 3. Maven `~/.m2/settings.xml`
+
+Recent Apache/Sling parent POMs use **maven-gpg-plugin 3.x**, which changed how the GPG passphrase is
+supplied. The old approach of a `<gpg.passphrase>` property in the `apache-release` profile is **no
+longer used** — the plugin now reads the passphrase from a **server** whose id is given by
+`gpg.passphraseServerId` (default: `gpg.passphrase`) and decrypts it via `settings-security.xml`.
+
+```xml
+<settings>
+  <servers>
+    <!-- ASF Nexus credentials (encrypted, see settings-security.xml) -->
+    <server>
+      <id>apache.snapshots.https</id>
+      <username>your-apache-id</username>
+      <password>{ENCRYPTED}</password>
+    </server>
+    <server>
+      <id>apache.releases.https</id>
+      <username>your-apache-id</username>
+      <password>{ENCRYPTED}</password>
+    </server>
+
+    <!-- maven-gpg-plugin 3.x reads the passphrase from THIS server id (gpg.passphraseServerId
+         defaults to "gpg.passphrase") and decrypts it via settings-security.xml. -->
+    <server>
+      <id>gpg.passphrase</id>
+      <passphrase>{ENCRYPTED}</passphrase>
+    </server>
+  </servers>
+  <profiles>
+    <profile>
+      <id>apache-release</id>
+      <properties>
+        <apache.availid>your-apache-id</apache.availid>
+        <!-- required so gpg does not try to open an interactive pinentry dialog -->
+        <gpg.pinentryMode>loopback</gpg.pinentryMode>
+        <!-- the signing key id from step 2 -->
+        <gpg.keyname>YOUR_KEY_ID</gpg.keyname>
+        <!-- SMTP host used by the parent POM's announcement tooling -->
+        <smtp.host>smtp.gmail.com</smtp.host>
+      </properties>
+    </profile>
+  </profiles>
+</settings>
+```
+
+Encrypt the passwords/passphrase with `mvn --encrypt-password` (server passwords) and store the master
+password in `~/.m2/settings-security.xml`:
+
+```xml
+<settingsSecurity>
+  <master>{ENCRYPTED_MASTER_PASSWORD}</master>
+</settingsSecurity>
+```
+
+## Building
+
+The Docker image (`apache/sling-cli:latest`) is produced by the `docker:build` goal of the
+[fabric8 docker-maven-plugin](https://dmp.fabric8.io/). The image bundles the project jar via the
+generated `*-app.slingfeature` descriptor; the `slingfeature-maven-plugin` resolves the project's
+own bundle from the reactor, so the image always contains the jar built in the same invocation.
+
+A single command builds (and tests) the project and the image:
+
+    mvn clean package docker:build
+
+No prior `mvn install` is needed. The `docker:build` execution is also bound to the `package`
+phase, so the CI build (`mvn package`) builds the image too.
+
+To confirm the image contains the expected commands:
+
+    docker run --env-file=./docker-env apache/sling-cli release help
 
 ## Launching
 
-The image is built using `mvn package`. Afterwards it may be run with
+After building, run the image with:
 
     docker run --env-file=./docker-env apache/sling-cli
-    
+
 This invocation produces a list of available commands.
 
 ## Commands
@@ -39,21 +130,102 @@ To select a non-default execution mode provide the mode as an argument to the co
 Note that for running commands in the `INTERACTIVE` mode you need to run the Docker container in interactive mode with a pseudo-tty 
 attached (e.g. `docker run -it ...`).
 
-Listing active releases
+### Release workflow
 
-    docker run --env-file=./docker-env apache/sling-cli release list
+The full release lifecycle has **manual Maven steps** (run in the project being released) and **CLI
+steps** (run via this Docker tool). The CLI commands take the numeric staging repository id via
+`-r`/`--repository` (e.g. `3103` for `orgapachesling-3103`). Append `-x AUTO` to actually perform an
+action (the default mode is `DRY_RUN`).
 
-Generating a release vote email
+#### Manual steps in the project being released (Maven)
 
-    docker run --env-file=./docker-env apache/sling-cli release prepare-email --repository=$STAGING_REPOSITORY_ID
-    
-Generating a release vote result email
+These are **not** part of this tool — run them in the module you are releasing, with the prerequisites
+from the section above configured:
 
-    docker run --env-file=./docker-env apache/sling-cli release tally-votes --repository=$STAGING_REPOSITORY_ID
-    
-Generating the website update (only diff for now)
+1. Make sure the parent POM is up to date and the build is green (`mvn clean verify`).
+2. Dry-run the release and check that only `<version>`/`<scm>` change:
 
-	docker run --env-file=docker-env apache/sling-cli release update-local-site --repository=$STAGING_REPOSITORY_ID
+       mvn release:prepare -DdryRun=true
+       mvn release:clean
+
+3. Deploy a snapshot and confirm `META-INF/LICENSE` and `META-INF/NOTICE` are in the jar:
+
+       mvn deploy
+
+4. Prepare and perform the release (creates the tag, bumps to the next SNAPSHOT, signs and stages the
+   artifacts to Nexus):
+
+       mvn release:prepare
+       mvn release:perform
+
+   Note the staging repository id from the `release:perform` output (a line like
+   `…/orgapachesling-1087`). If it scrolls past, `release list` (below) shows open repos too.
+
+#### CLI steps (this tool)
+
+After `release:perform` has staged the artifacts, drive the rest with the CLI:
+
+0. **Find the staging repository id** if you did not capture it. `release list` shows every staging
+   repo with its `[open]`/`[closed]` state and description; a freshly staged one is `[open]`:
+
+       docker run --env-file=./docker-env apache/sling-cli release list
+
+1. **Close** the staging repository. The description is derived automatically from the staged POM's
+   `<name>` + `<version>` (e.g. _Apache Sling Feature Model Launcher 1.3.6_) by browsing the
+   repository content, so it works even though an open repository is not yet in the Lucene index:
+
+       docker run --env-file=./docker-env apache/sling-cli release close-staging --repository=$STAGING_REPOSITORY_ID --execution-mode=AUTO
+
+2. **Verify** the artifacts' signatures, hashes and CI status:
+
+       docker run --env-file=./docker-env apache/sling-cli release verify --repository=$STAGING_REPOSITORY_ID
+
+3. **Generate the vote email**:
+
+       docker run --env-file=./docker-env apache/sling-cli release prepare-email --repository=$STAGING_REPOSITORY_ID --execution-mode=AUTO
+
+4. After the 72h vote, **tally the votes** and generate the result email. PMC membership is detected
+   automatically from your ASF id: if you are a PMC member the email says you will copy the release to
+   the dist directory yourself; otherwise it asks a PMC member to perform the dist upload:
+
+       docker run --env-file=./docker-env apache/sling-cli release tally-votes --repository=$STAGING_REPOSITORY_ID --execution-mode=AUTO
+
+5. **Finalize** the release (post successful vote). This runs, in order: promote to Maven Central,
+   create the next Jira version, release the current Jira version, and update the Apache Reporter:
+
+       docker run --env-file=./docker-env apache/sling-cli release finalize --repository=$STAGING_REPOSITORY_ID --execution-mode=AUTO
+
+   When the current user is detected as a PMC member, `finalize` additionally publishes to
+   `dist.apache.org` (requires `subversion`, which is bundled in the image). The previous version to
+   remove from `dist/release` is deduced automatically from the directory contents, so no extra flag
+   is needed:
+
+       docker run --env-file=./docker-env apache/sling-cli release finalize --repository=$STAGING_REPOSITORY_ID --execution-mode=AUTO
+
+   PMC membership is determined from your ASF id (via Whimsy). A non-PMC committer's `finalize` skips
+   the dist upload and the `tally-votes` result email asks a PMC member to perform it.
+
+If the vote does not pass, **drop** the staging repository:
+
+    docker run --env-file=./docker-env apache/sling-cli release drop --repository=$STAGING_REPOSITORY_ID --execution-mode=AUTO
+
+### Command reference
+
+| Command | Description |
+|---------|-------------|
+| `release list` | List closed staging repositories |
+| `release close-staging -r <id>` | Close an open staging repo, setting the description from the staged POM |
+| `release verify -r <id>` | Download and verify artifact signatures, hashes and CI status |
+| `release prepare-email -r <id>` | Generate (and send) the `[VOTE]` email |
+| `release tally-votes -r <id>` | Count votes and generate the `[RESULT]` email (PMC membership auto-detected; non-PMC email asks a PMC member to do the dist upload) |
+| `release promote -r <id>` | Promote a closed staging repo to Maven Central |
+| `release update-dist -r <id>` | Move artifacts to `dist.apache.org` (PMC only); previous version auto-deduced, override with `--previous-version <v>` |
+| `release finalize -r <id>` | Promote + Jira + Reporter in one step; also updates `dist.apache.org` when you are a PMC member |
+| `release drop -r <id>` | Drop a staging repository (failed vote / cleanup) |
+| `release create-new-jira-version -r <id>` | Create the next Jira version and move unresolved issues |
+| `release release-jira-version -r <id>` | Mark the Jira version as released and close fixed issues |
+| `release update-reporter -r <id>` | Register the release with the Apache Reporter System |
+| `release update-local-site -r <id>` | Generate the website update (diff only for now) |
 
 ## Assumptions
 

--- a/src/main/java/org/apache/sling/cli/impl/jira/VersionClient.java
+++ b/src/main/java/org/apache/sling/cli/impl/jira/VersionClient.java
@@ -25,6 +25,9 @@ import java.io.StringWriter;
 import java.lang.reflect.Type;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -34,6 +37,7 @@ import java.util.stream.Collectors;
 import com.google.gson.Gson;
 import com.google.gson.JsonIOException;
 import com.google.gson.JsonSyntaxException;
+import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonWriter;
 import org.apache.http.HttpHeaders;
@@ -210,6 +214,113 @@ public class VersionClient {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Finds issues that were tagged with the release's fix version <em>after</em> {@code stagedAt}.
+     *
+     * <p>Such issues cannot be part of a release whose artifacts were already staged at that point; a
+     * common cause is a committer tagging an issue with a fix version that was already staged and out
+     * for a vote (see SLING-13260).</p>
+     *
+     * @param release the release whose fix version is checked
+     * @param stagedAt the moment the release artifacts were staged
+     * @return the issues tagged with the fix version after {@code stagedAt}, never {@code null}
+     * @throws IOException in case of any errors talking to JIRA
+     */
+    public List<Issue> findIssuesFixVersionedAfter(Release release, Instant stagedAt) throws IOException {
+        return findIssuesFixVersionedAfter(release, findIssues(release), stagedAt);
+    }
+
+    private List<Issue> findIssuesFixVersionedAfter(Release release, List<Issue> issues, Instant stagedAt)
+            throws IOException {
+        List<Issue> late = new ArrayList<>();
+        for (Issue issue : issues) {
+            if (issue.getResolution() == null) {
+                // unresolved issues are moved to the next version rather than closed, so they are not a concern
+                continue;
+            }
+            Instant addedAt = findFixVersionAddedDate(issue, release.getName());
+            if (addedAt != null && addedAt.isAfter(stagedAt)) {
+                late.add(issue);
+            }
+        }
+        return late;
+    }
+
+    /**
+     * Returns the most recent moment the given fix version was added to the issue, according to its
+     * change history, or {@code null} if that cannot be determined.
+     */
+    private Instant findFixVersionAddedDate(Issue issue, String versionName) throws IOException {
+        try {
+            HttpGet get = newGet("issue/" + issue.getKey());
+            URIBuilder builder = new URIBuilder(get.getURI());
+            builder.addParameter("expand", "changelog");
+            builder.addParameter("fields", ""); // only the changelog is needed
+            get.setURI(builder.build());
+
+            try (CloseableHttpClient client = httpClientFactory.newClient()) {
+                try (CloseableHttpResponse response = client.execute(get)) {
+                    try (InputStream content = response.getEntity().getContent();
+                            InputStreamReader reader = new InputStreamReader(content)) {
+
+                        if (response.getStatusLine().getStatusCode() != 200) {
+                            throw newException(response, reader);
+                        }
+
+                        Changelog changelog = new Gson().fromJson(reader, IssueChangelog.class).changelog;
+                        if (changelog == null || changelog.histories == null) {
+                            return null;
+                        }
+                        Instant latest = null;
+                        for (History history : changelog.histories) {
+                            if (history.items == null || history.created == null) {
+                                continue;
+                            }
+                            for (HistoryItem item : history.items) {
+                                boolean isFixVersionChange = "fixVersions".equals(item.fieldId)
+                                        || (item.field != null && item.field.equalsIgnoreCase("Fix Version"));
+                                if (isFixVersionChange && versionName.equals(item.toString)) {
+                                    Instant when = OffsetDateTime.parse(history.created, JIRA_TIMESTAMP)
+                                            .toInstant();
+                                    if (latest == null || when.isAfter(latest)) {
+                                        latest = when;
+                                    }
+                                }
+                            }
+                        }
+                        return latest;
+                    }
+                }
+            }
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    // JIRA change-history timestamps, e.g. "2024-01-15T10:30:00.000+0000"
+    private static final DateTimeFormatter JIRA_TIMESTAMP = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+
+    static class IssueChangelog {
+        private Changelog changelog;
+    }
+
+    static class Changelog {
+        private List<History> histories;
+    }
+
+    static class History {
+        private String created;
+        private List<HistoryItem> items;
+    }
+
+    static class HistoryItem {
+        private String field;
+        private String fieldId;
+
+        @SerializedName("toString")
+        private String toString;
+    }
+
     private void closeIssues(List<Issue> issues) throws Exception {
         List<Promise<Issue>> closedIssues = new ArrayList<>();
         for (Issue issue : issues) {
@@ -235,6 +346,23 @@ public class VersionClient {
     }
 
     public void release(Release release) throws Exception {
+        release(release, null);
+    }
+
+    /**
+     * Marks the JIRA version matching the {@code release} as released and closes all its fixed issues.
+     *
+     * <p>When {@code stagedAt} is provided (the moment the release artifacts were staged in Nexus), this
+     * first guards against issues that acquired the release's fix version <em>after</em> the artifacts
+     * were staged: such issues cannot physically be part of the release, so closing them under this
+     * version would be wrong. If any are found the release is aborted before anything is closed, so a
+     * human can correct the fix-version tagging. See SLING-13260.</p>
+     *
+     * @param release the release to mark as released
+     * @param stagedAt the moment the artifacts were staged, or {@code null} to skip the staleness guard
+     * @throws Exception on any error, or when unresolved / late-tagged issues are found
+     */
+    public void release(Release release, Instant stagedAt) throws Exception {
         List<Issue> issues = findIssues(release);
         List<Issue> unresolvedIssues = new ArrayList<>();
         issues.forEach(issue -> {
@@ -243,6 +371,19 @@ public class VersionClient {
             }
         });
         if (unresolvedIssues.isEmpty()) {
+            if (stagedAt != null) {
+                List<Issue> lateIssues = findIssuesFixVersionedAfter(release, issues, stagedAt);
+                if (!lateIssues.isEmpty()) {
+                    String report = lateIssues.stream()
+                            .map(issue -> String.format("%s/browse/%s", jiraURL, issue.getKey()))
+                            .collect(Collectors.joining(System.lineSeparator()));
+                    throw new IllegalStateException(String.format(
+                            "The following issues were tagged with fix version \"%s\" after the release artifacts were "
+                                    + "staged (%s), so they cannot be part of the release and must not be closed under "
+                                    + "it. Re-tag them to the correct fix version before finalizing:%n%s",
+                            release.getName(), stagedAt, report));
+                }
+            }
             closeIssues(issues);
             Version version = find(release);
             if (!version.isReleased()) {

--- a/src/main/java/org/apache/sling/cli/impl/jira/VersionClient.java
+++ b/src/main/java/org/apache/sling/cli/impl/jira/VersionClient.java
@@ -285,20 +285,25 @@ public class VersionClient {
         }
         Instant latest = null;
         for (History history : changelog.histories) {
-            if (history.items == null || history.created == null) {
-                continue;
-            }
-            for (HistoryItem item : history.items) {
-                if (isFixVersionAddition(item, versionName)) {
-                    Instant when = OffsetDateTime.parse(history.created, JIRA_TIMESTAMP)
-                            .toInstant();
-                    if (latest == null || when.isAfter(latest)) {
-                        latest = when;
-                    }
-                }
+            Instant when = fixVersionChangeInstant(history, versionName);
+            if (when != null && (latest == null || when.isAfter(latest))) {
+                latest = when;
             }
         }
         return latest;
+    }
+
+    /** The timestamp of {@code history} when it records adding {@code versionName} to the fix versions, else null. */
+    private static Instant fixVersionChangeInstant(History history, String versionName) {
+        if (history.items == null || history.created == null) {
+            return null;
+        }
+        for (HistoryItem item : history.items) {
+            if (isFixVersionAddition(item, versionName)) {
+                return OffsetDateTime.parse(history.created, JIRA_TIMESTAMP).toInstant();
+            }
+        }
+        return null;
     }
 
     private static boolean isFixVersionAddition(HistoryItem item, String versionName) {

--- a/src/main/java/org/apache/sling/cli/impl/jira/VersionClient.java
+++ b/src/main/java/org/apache/sling/cli/impl/jira/VersionClient.java
@@ -73,6 +73,8 @@ public class VersionClient {
     private static final String PROJECT_KEY = "SLING";
     private static final String DEFAULT_JIRA_URL = "https://issues.apache.org/jira";
     private static final String CONTENT_TYPE_JSON = "application/json";
+    private static final String ISSUE_PATH = "issue/";
+    private static final String FIX_VERSIONS_FIELD = "fixVersions";
 
     private final PromiseFactory promiseFactory = new PromiseFactory(null, null);
 
@@ -251,50 +253,58 @@ public class VersionClient {
      * change history, or {@code null} if that cannot be determined.
      */
     private Instant findFixVersionAddedDate(Issue issue, String versionName) throws IOException {
+        HttpGet get = newGet(ISSUE_PATH + issue.getKey());
         try {
-            HttpGet get = newGet("issue/" + issue.getKey());
             URIBuilder builder = new URIBuilder(get.getURI());
             builder.addParameter("expand", "changelog");
             builder.addParameter("fields", ""); // only the changelog is needed
             get.setURI(builder.build());
-
-            try (CloseableHttpClient client = httpClientFactory.newClient()) {
-                try (CloseableHttpResponse response = client.execute(get)) {
-                    try (InputStream content = response.getEntity().getContent();
-                            InputStreamReader reader = new InputStreamReader(content)) {
-
-                        if (response.getStatusLine().getStatusCode() != 200) {
-                            throw newException(response, reader);
-                        }
-
-                        Changelog changelog = new Gson().fromJson(reader, IssueChangelog.class).changelog;
-                        if (changelog == null || changelog.histories == null) {
-                            return null;
-                        }
-                        Instant latest = null;
-                        for (History history : changelog.histories) {
-                            if (history.items == null || history.created == null) {
-                                continue;
-                            }
-                            for (HistoryItem item : history.items) {
-                                boolean isFixVersionChange = "fixVersions".equals(item.fieldId)
-                                        || (item.field != null && item.field.equalsIgnoreCase("Fix Version"));
-                                if (isFixVersionChange && versionName.equals(item.toString)) {
-                                    Instant when = OffsetDateTime.parse(history.created, JIRA_TIMESTAMP)
-                                            .toInstant();
-                                    if (latest == null || when.isAfter(latest)) {
-                                        latest = when;
-                                    }
-                                }
-                            }
-                        }
-                        return latest;
-                    }
-                }
-            }
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }
+
+        try (CloseableHttpClient client = httpClientFactory.newClient();
+                CloseableHttpResponse response = client.execute(get);
+                InputStream content = response.getEntity().getContent();
+                InputStreamReader reader = new InputStreamReader(content)) {
+            if (response.getStatusLine().getStatusCode() != 200) {
+                throw newException(response, reader);
+            }
+            Changelog changelog = new Gson().fromJson(reader, IssueChangelog.class).changelog;
+            return latestFixVersionChange(changelog, versionName);
+        }
+    }
+
+    /**
+     * Scans a Jira changelog for the most recent moment {@code versionName} was added to the issue's fix
+     * versions, or {@code null} if the changelog is empty or records no such change.
+     */
+    private static Instant latestFixVersionChange(Changelog changelog, String versionName) {
+        if (changelog == null || changelog.histories == null) {
+            return null;
+        }
+        Instant latest = null;
+        for (History history : changelog.histories) {
+            if (history.items == null || history.created == null) {
+                continue;
+            }
+            for (HistoryItem item : history.items) {
+                if (isFixVersionAddition(item, versionName)) {
+                    Instant when = OffsetDateTime.parse(history.created, JIRA_TIMESTAMP)
+                            .toInstant();
+                    if (latest == null || when.isAfter(latest)) {
+                        latest = when;
+                    }
+                }
+            }
+        }
+        return latest;
+    }
+
+    private static boolean isFixVersionAddition(HistoryItem item, String versionName) {
+        boolean isFixVersionChange = FIX_VERSIONS_FIELD.equals(item.fieldId)
+                || (item.field != null && item.field.equalsIgnoreCase("Fix Version"));
+        return isFixVersionChange && versionName.equals(item.toString);
     }
 
     // JIRA change-history timestamps, e.g. "2024-01-15T10:30:00.000+0000"
@@ -552,12 +562,12 @@ public class VersionClient {
             StringWriter w = new StringWriter();
 
             IssueUpdate update = new IssueUpdate();
-            update.recordAdd("fixVersions", newVersion.getName());
-            update.recordRemove("fixVersions", oldVersion.getName());
+            update.recordAdd(FIX_VERSIONS_FIELD, newVersion.getName());
+            update.recordRemove(FIX_VERSIONS_FIELD, oldVersion.getName());
             Gson gson = new Gson();
             gson.toJson(update, w);
 
-            HttpPut put = newPut("issue/" + issue.getKey());
+            HttpPut put = newPut(ISSUE_PATH + issue.getKey());
             put.setEntity(new StringEntity(w.toString(), StandardCharsets.UTF_8));
 
             try (CloseableHttpClient client = httpClientFactory.newClient()) {
@@ -577,7 +587,7 @@ public class VersionClient {
     }
 
     private Promise<Transition> getCloseTransition(Issue issue) {
-        HttpGet get = newGet("issue/" + issue.getId() + "/transitions");
+        HttpGet get = newGet(ISSUE_PATH + issue.getId() + "/transitions");
         try {
             try (CloseableHttpClient client = httpClientFactory.newClient()) {
                 try (CloseableHttpResponse getResponse =
@@ -609,7 +619,7 @@ public class VersionClient {
     }
 
     private Promise<Issue> closeIssue(Issue issue, Transition closeTransition) {
-        HttpPost post = newPost("issue/" + issue.getId() + "/transitions");
+        HttpPost post = newPost(ISSUE_PATH + issue.getId() + "/transitions");
         StringWriter w = new StringWriter();
         try (JsonWriter jw = new Gson().newJsonWriter(w)) {
             jw.beginObject()

--- a/src/main/java/org/apache/sling/cli/impl/mail/VoteThreadFinder.java
+++ b/src/main/java/org/apache/sling/cli/impl/mail/VoteThreadFinder.java
@@ -42,10 +42,13 @@ public class VoteThreadFinder {
     public List<Email> findVoteThread(String releaseName) throws IOException {
         try (CloseableHttpClient client = HttpClients.createDefault()) {
             String threadSubject = "[VOTE] Release " + releaseName;
+            // Look back 6 months: a vote may be tallied well after the 72h period ends, so a 1-month
+            // window can miss threads for releases that linger before being finalized. The version in
+            // the query keeps the match specific to a single release.
             URI uri = new URIBuilder("https://lists.apache.org/api/stats.lua")
                     .addParameter("domain", "sling.apache.org")
                     .addParameter("list", "dev")
-                    .addParameter("d", "lte=1M")
+                    .addParameter("d", "lte=6M")
                     .addParameter("q", threadSubject)
                     .build();
 

--- a/src/main/java/org/apache/sling/cli/impl/nexus/StagingRepository.java
+++ b/src/main/java/org/apache/sling/cli/impl/nexus/StagingRepository.java
@@ -18,6 +18,8 @@
  */
 package org.apache.sling.cli.impl.nexus;
 
+import java.time.Instant;
+
 /**
  * DTO for GSON usage
  *
@@ -34,6 +36,17 @@ public class StagingRepository {
     protected String repositoryURI;
     protected Status type;
     protected String userId;
+    protected long createdTimestamp;
+
+    /**
+     * Returns the moment this staging repository was created in Nexus, i.e. when the release artifacts
+     * were staged. Anything resolved in JIRA after this point cannot be part of the release.
+     *
+     * @return the creation instant, or {@code null} if Nexus did not report one
+     */
+    public Instant getCreated() {
+        return createdTimestamp > 0 ? Instant.ofEpochMilli(createdTimestamp) : null;
+    }
 
     public String getDescription() {
         return description;

--- a/src/main/java/org/apache/sling/cli/impl/release/CreateJiraVersionCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/CreateJiraVersionCommand.java
@@ -23,11 +23,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.apache.sling.cli.impl.Command;
-import org.apache.sling.cli.impl.ExecutionMode;
-import org.apache.sling.cli.impl.InputOption;
-import org.apache.sling.cli.impl.UserInput;
-import org.apache.sling.cli.impl.jira.Issue;
-import org.apache.sling.cli.impl.jira.Version;
 import org.apache.sling.cli.impl.jira.VersionClient;
 import org.apache.sling.cli.impl.nexus.RepositoryService;
 import org.osgi.service.component.annotations.Component;
@@ -85,61 +80,9 @@ public class CreateJiraVersionCommand implements Command {
                 return CommandLine.ExitCode.USAGE;
             }
             for (Release release : releases) {
-                Version version = versionClient.find(release);
-                logger.info("Found {}.", version);
-                Version successorVersion = versionClient.findSuccessorVersion(release);
-                boolean createNextRelease = false;
-                if (successorVersion == null) {
-                    Release next = release.next();
-                    if (reusableCLIOptions.executionMode == ExecutionMode.DRY_RUN) {
-                        logger.info("Version {} would be created.", next.getName());
-                    } else if (reusableCLIOptions.executionMode == ExecutionMode.INTERACTIVE) {
-                        InputOption answer = UserInput.yesNo(
-                                String.format("Should version %s be created?", next.getName()), InputOption.YES);
-                        createNextRelease = (answer == InputOption.YES);
-                    } else if (reusableCLIOptions.executionMode == ExecutionMode.AUTO) {
-                        createNextRelease = true;
-                    }
-                    if (createNextRelease) {
-                        versionClient.create(next.getName());
-                        logger.info("Created version {}", next.getName());
-                        successorVersion = versionClient.findSuccessorVersion(release);
-                    }
-                } else {
-                    logger.info("Found successor {}.", successorVersion);
-                }
-                if (successorVersion != null) {
-                    List<Issue> unresolvedIssues = versionClient.findUnresolvedIssues(release);
-                    if (!unresolvedIssues.isEmpty()) {
-                        boolean moveIssues = false;
-                        if (reusableCLIOptions.executionMode == ExecutionMode.DRY_RUN) {
-                            logger.info(
-                                    "{} unresolved issues would be moved from version {} to version {} :",
-                                    unresolvedIssues.size(),
-                                    version.getName(),
-                                    successorVersion.getName());
-                        } else if (reusableCLIOptions.executionMode == ExecutionMode.INTERACTIVE) {
-                            InputOption answer = UserInput.yesNo(
-                                    String.format(
-                                            "Should the %s unresolved issue(s) from version %s be " + "moved "
-                                                    + "to version %s?",
-                                            unresolvedIssues.size(), version.getName(), successorVersion.getName()),
-                                    InputOption.YES);
-                            moveIssues = (answer == InputOption.YES);
-                        } else if (reusableCLIOptions.executionMode == ExecutionMode.AUTO) {
-                            moveIssues = true;
-                        }
-                        if (moveIssues) {
-                            logger.info(
-                                    "Moving the following issues from {} to {}.",
-                                    version.getName(),
-                                    successorVersion.getName());
-                            unresolvedIssues.forEach(i -> logger.info("- {} : {}", i.getKey(), i.getSummary()));
-                            versionClient.moveIssuesToNewVersion(version, successorVersion, unresolvedIssues);
-                            logger.info("Done.");
-                        }
-                    }
-                }
+                logger.info("Found {}.", versionClient.find(release));
+                JiraVersions.createSuccessorAndMoveUnresolved(
+                        versionClient, release, reusableCLIOptions.executionMode, logger);
             }
         } catch (IOException e) {
             logger.warn("Failed executing command", e);

--- a/src/main/java/org/apache/sling/cli/impl/release/FinalizeCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/FinalizeCommand.java
@@ -19,36 +19,17 @@
 package org.apache.sling.cli.impl.release;
 
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.util.EntityUtils;
 import org.apache.sling.cli.impl.Command;
-import org.apache.sling.cli.impl.Credentials;
 import org.apache.sling.cli.impl.CredentialsService;
 import org.apache.sling.cli.impl.ExecutionMode;
 import org.apache.sling.cli.impl.http.HttpClientFactory;
 import org.apache.sling.cli.impl.jira.Issue;
-import org.apache.sling.cli.impl.jira.Version;
 import org.apache.sling.cli.impl.jira.VersionClient;
-import org.apache.sling.cli.impl.nexus.Artifact;
-import org.apache.sling.cli.impl.nexus.LocalRepository;
 import org.apache.sling.cli.impl.nexus.RepositoryService;
 import org.apache.sling.cli.impl.nexus.StagingRepository;
 import org.apache.sling.cli.impl.people.MembersFinder;
@@ -102,9 +83,6 @@ public class FinalizeCommand implements Command {
     static final String NAME = "finalize";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FinalizeCommand.class);
-
-    private static final String REPORTER_OVERVIEW_URL = "https://reporter.apache.org/api/overview?sling";
-    private static final String REPORTER_COMMITTEE = "sling";
 
     @CommandLine.Option(
             names = {"-r", "--repository"},
@@ -266,68 +244,42 @@ public class FinalizeCommand implements Command {
     }
 
     private void stepUpdateDist(StagingRepository repository, ExecutionMode mode) throws IOException {
-        LocalRepository localRepository = repositoryService.download(repository);
-        Artifact primary = localRepository.getArtifacts().stream()
-                .filter(a -> "pom".equals(a.getType()))
-                .findFirst()
-                .orElseThrow(() -> new IllegalStateException("No POM artifact found"));
+        // Delegate the download/collect/publish flow to UpdateDistCommand so it is not duplicated here.
+        UpdateDistCommand.DistReleasePlan plan = UpdateDistCommand.planDistRelease(repositoryService, repository, null);
 
-        String artifactId = primary.getArtifactId();
-        String newVersion = primary.getVersion();
-
-        if (UpdateDistCommand.isVersionPublished(artifactId, newVersion)) {
-            LOGGER.info("dist/release already contains {} {}; skipping.", artifactId, newVersion);
+        if (plan.alreadyPublished()) {
+            LOGGER.info("dist/release already contains {} {}; skipping.", plan.artifactId(), plan.newVersion());
             return;
         }
-
-        // Publish the staged artifacts (downloaded from Nexus) to dist/release; Maven releases never
-        // stage to dist/dev. The previous version to remove is deduced from the current dist/release.
-        List<Path> newFiles = UpdateDistCommand.collectDownloadedFiles(localRepository.getRootFolder());
-        List<String> oldFiles = UpdateDistCommand.listPreviousReleaseFiles(artifactId, newVersion, null);
-
-        if (newFiles.isEmpty()) {
-            LOGGER.warn("No artifacts were downloaded for {} {}; skipping dist update.", artifactId, newVersion);
+        if (plan.newFiles().isEmpty()) {
+            LOGGER.warn(
+                    "No artifacts were downloaded for {} {}; skipping dist update.",
+                    plan.artifactId(),
+                    plan.newVersion());
             return;
         }
 
         if (mode == ExecutionMode.DRY_RUN) {
-            LOGGER.info("Would publish {} file(s) to dist/release for {} {}", newFiles.size(), artifactId, newVersion);
-            LOGGER.info("Would remove {} old file(s) from dist/release", oldFiles.size());
+            LOGGER.info(
+                    "Would publish {} file(s) to dist/release for {} {}",
+                    plan.newFiles().size(),
+                    plan.artifactId(),
+                    plan.newVersion());
+            LOGGER.info(
+                    "Would remove {} old file(s) from dist/release",
+                    plan.oldFiles().size());
         } else {
-            Credentials creds = credentialsService.getAsfCredentials();
-            UpdateDistCommand.publishToDistRelease(artifactId, newVersion, newFiles, oldFiles, creds);
+            UpdateDistCommand.publishToDistRelease(
+                    plan.artifactId(),
+                    plan.newVersion(),
+                    plan.newFiles(),
+                    plan.oldFiles(),
+                    credentialsService.getAsfCredentials());
         }
     }
 
     private void stepCreateNextJiraVersion(Release release, ExecutionMode mode) throws IOException {
-        Version successorVersion = versionClient.findSuccessorVersion(release);
-        if (successorVersion == null) {
-            Release next = release.next();
-            if (mode == ExecutionMode.DRY_RUN) {
-                LOGGER.info("Would create JIRA version {}", next.getName());
-            } else {
-                versionClient.create(next.getName());
-                LOGGER.info("Created JIRA version {}", next.getName());
-                successorVersion = versionClient.findSuccessorVersion(release);
-            }
-        } else {
-            LOGGER.info("Successor JIRA version {} already exists", successorVersion.getName());
-        }
-        if (successorVersion != null) {
-            List<Issue> unresolved = versionClient.findUnresolvedIssues(release);
-            if (!unresolved.isEmpty()) {
-                if (mode == ExecutionMode.DRY_RUN) {
-                    LOGGER.info(
-                            "Would move {} unresolved issue(s) from {} to {}",
-                            unresolved.size(),
-                            release.getName(),
-                            successorVersion.getName());
-                } else {
-                    versionClient.moveIssuesToNewVersion(versionClient.find(release), successorVersion, unresolved);
-                    LOGGER.info("Moved {} unresolved issue(s) to {}", unresolved.size(), successorVersion.getName());
-                }
-            }
-        }
+        JiraVersions.createSuccessorAndMoveUnresolved(versionClient, release, mode, LOGGER);
     }
 
     /**
@@ -364,74 +316,23 @@ public class FinalizeCommand implements Command {
     private void stepUpdateReporter(Set<Release> releases) throws IOException {
         try (CloseableHttpClient client = httpClientFactory.newClient()) {
             // Query first so a resumed run does not add a release the reporter already lists.
-            Set<String> alreadyRecorded = fetchRecordedReporterReleases(client);
-            Instant now = Instant.now();
-            String xdate = DateTimeFormatter.ISO_LOCAL_DATE
-                    .withZone(ZoneId.systemDefault())
-                    .format(now);
+            Set<String> alreadyRecorded = Reporter.fetchRegisteredReleaseNames(client);
             for (Release release : releases) {
                 if (alreadyRecorded != null && alreadyRecorded.contains(release.getFullName())) {
                     LOGGER.info("Apache Reporter already lists {}; skipping.", release.getFullName());
                     continue;
                 }
-                HttpPost post = new HttpPost("https://reporter.apache.org/addrelease.py");
-                List<NameValuePair> params = new ArrayList<>();
-                params.add(new BasicNameValuePair("date", Long.toString(now.getEpochSecond())));
-                params.add(new BasicNameValuePair("committee", REPORTER_COMMITTEE));
-                params.add(new BasicNameValuePair("version", release.getFullName()));
-                params.add(new BasicNameValuePair("xdate", xdate));
-                post.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
-                try (CloseableHttpResponse response = client.execute(post)) {
-                    int statusCode = response.getStatusLine().getStatusCode();
-                    // addrelease.py returns HTTP 200 even on failure, with the error in the body, so the
-                    // status code alone is not enough to tell success from failure.
-                    String body = response.getEntity() == null
-                            ? ""
-                            : EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8)
-                                    .strip();
-                    if (statusCode == 200 && !body.contains("Could not save")) {
-                        LOGGER.info("Updated Apache Reporter for {}", release.getFullName());
-                    } else if (body.toLowerCase().contains("access to this committee data")) {
-                        // release data is committee-scoped; a non-PMC user cannot add it
-                        LOGGER.warn(
-                                "Apache Reporter NOT updated for {} — the current user lacks committee access; a PMC"
-                                        + " member must add it. Reporter said: {}",
-                                release.getFullName(),
-                                body);
-                    } else {
-                        throw new IOException("Reporter update failed for " + release.getFullName() + ": HTTP "
-                                + statusCode + (body.isEmpty() ? "" : " - " + body));
-                    }
+                // Reporter release data is committee-scoped; a non-PMC / non-ASF-member user cannot add it.
+                // Like the dist step, treat that as a skip-with-warning rather than a hard failure.
+                if (Reporter.addRelease(client, release) == Reporter.Result.ACCESS_DENIED) {
+                    LOGGER.warn(
+                            "Apache Reporter NOT updated for {} — the current user lacks committee access; a PMC"
+                                    + " member must add it.",
+                            release.getFullName());
+                } else {
+                    LOGGER.info("Updated Apache Reporter for {}", release.getFullName());
                 }
             }
-        }
-    }
-
-    /**
-     * Fetches the set of release names the Apache Reporter already records for the Sling committee, so a
-     * resumed run can skip re-adding them. Returns {@code null} if the reporter could not be queried, in
-     * which case the caller should post without deduplication rather than risk skipping a real release.
-     */
-    private Set<String> fetchRecordedReporterReleases(CloseableHttpClient client) {
-        HttpGet get = new HttpGet(REPORTER_OVERVIEW_URL);
-        get.setHeader("Accept", "application/json");
-        try (CloseableHttpResponse response = client.execute(get)) {
-            int statusCode = response.getStatusLine().getStatusCode();
-            if (statusCode != 200 || response.getEntity() == null) {
-                LOGGER.warn("Could not query Apache Reporter (HTTP {}); will post without deduplication.", statusCode);
-                return null;
-            }
-            try (InputStreamReader reader =
-                    new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8)) {
-                JsonObject root = new Gson().fromJson(reader, JsonObject.class);
-                JsonObject releases = root == null ? null : root.getAsJsonObject("releases");
-                JsonObject committeeReleases = releases == null ? null : releases.getAsJsonObject(REPORTER_COMMITTEE);
-                // the reporter keys each release by its full name (e.g. "Apache Sling API 2.27.6")
-                return committeeReleases == null ? Set.of() : Set.copyOf(committeeReleases.keySet());
-            }
-        } catch (Exception e) {
-            LOGGER.warn("Could not query Apache Reporter ({}); will post without deduplication.", e.getMessage());
-            return null;
         }
     }
 }

--- a/src/main/java/org/apache/sling/cli/impl/release/FinalizeCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/FinalizeCommand.java
@@ -38,6 +38,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
 import org.apache.sling.cli.impl.Command;
 import org.apache.sling.cli.impl.Credentials;
 import org.apache.sling.cli.impl.CredentialsService;
@@ -381,12 +382,27 @@ public class FinalizeCommand implements Command {
                 params.add(new BasicNameValuePair("xdate", xdate));
                 post.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
                 try (CloseableHttpResponse response = client.execute(post)) {
-                    if (response.getStatusLine().getStatusCode() != 200) {
+                    int statusCode = response.getStatusLine().getStatusCode();
+                    // addrelease.py returns HTTP 200 even on failure, with the error in the body, so the
+                    // status code alone is not enough to tell success from failure.
+                    String body = response.getEntity() == null
+                            ? ""
+                            : EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8)
+                                    .strip();
+                    if (statusCode == 200 && !body.contains("Could not save")) {
+                        LOGGER.info("Updated Apache Reporter for {}", release.getFullName());
+                    } else if (body.toLowerCase().contains("access to this committee data")) {
+                        // release data is committee-scoped; a non-PMC user cannot add it
+                        LOGGER.warn(
+                                "Apache Reporter NOT updated for {} — the current user lacks committee access; a PMC"
+                                        + " member must add it. Reporter said: {}",
+                                release.getFullName(),
+                                body);
+                    } else {
                         throw new IOException("Reporter update failed for " + release.getFullName() + ": HTTP "
-                                + response.getStatusLine().getStatusCode());
+                                + statusCode + (body.isEmpty() ? "" : " - " + body));
                     }
                 }
-                LOGGER.info("Updated Apache Reporter for {}", release.getFullName());
             }
         }
     }

--- a/src/main/java/org/apache/sling/cli/impl/release/FinalizeCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/FinalizeCommand.java
@@ -121,117 +121,21 @@ public class FinalizeCommand implements Command {
     @Reference
     private MembersFinder membersFinder;
 
+    /** The finalize target: the staging repository (null once it has been promoted and dropped) and its releases. */
+    private record FinalizeTarget(StagingRepository repository, Set<Release> releases) {}
+
     @Override
     public Integer call() {
         try {
-            ExecutionMode mode = reusableCLIOptions.executionMode;
-            boolean isPmcMember = membersFinder.getCurrentMember().isPMCMember();
-
-            // Resolve the target releases. Before promotion, act by --repository (which still exists);
-            // to resume after promotion (which drops the repository), act by --release name instead.
-            StagingRepository repository;
-            Set<Release> releases;
-            if (repositoryId != null) {
-                try {
-                    repository = repositoryService.find(repositoryId);
-                } catch (IllegalArgumentException e) {
-                    LOGGER.error(
-                            "Staging repository {} was not found — it was most likely already promoted and"
-                                    + " dropped. Resume the remaining steps with --release \"<name>\" instead of"
-                                    + " --repository.",
-                            repositoryId);
-                    return CommandLine.ExitCode.USAGE;
-                }
-                releases = repositoryService.getReleases(repository);
-            } else if (releaseName != null && !releaseName.isBlank()) {
-                repository = null;
-                releases = Set.copyOf(Release.fromString(releaseName));
-            } else {
-                LOGGER.error("Provide either --repository <id> (initial run) or --release \"<name>\" (to resume after"
-                        + " the staging repository has been promoted).");
+            FinalizeTarget target = resolveTarget();
+            if (target == null) {
                 return CommandLine.ExitCode.USAGE;
             }
-
-            if (releases.isEmpty()) {
+            if (target.releases().isEmpty()) {
                 LOGGER.error("No releases could be resolved.");
                 return CommandLine.ExitCode.USAGE;
             }
-
-            Instant stagedAt = repository != null ? repository.getCreated() : null;
-
-            String releaseNames = releases.stream()
-                    .map(Release::getFullName)
-                    .reduce((a, b) -> a + ", " + b)
-                    .orElse("(none)");
-            LOGGER.info("=== Finalizing: {} ===", releaseNames);
-            if (repository == null) {
-                LOGGER.info("Resuming by release name; steps already completed before promotion are detected and"
-                        + " skipped.");
-            }
-
-            // Pre-flight: validate JIRA state *before* any irreversible action. Promoting to Maven Central drops
-            // the staging repository, so detecting a mis-tagged issue here lets the operator fix JIRA and re-run
-            // with nothing promoted or changed yet (SLING-13260). On a resume-by-name run there is no staging
-            // timestamp, so this is a no-op — it already passed on the initial run.
-            LOGGER.info("--- Pre-flight: validating JIRA state ---");
-            if (!preflightJiraState(releases, stagedAt)) {
-                LOGGER.error("Aborting finalize before any changes are made. Re-tag the issue(s) to the correct fix"
-                        + " version (or re-run with --force-close-late-issues), then run finalize again — nothing has"
-                        + " been promoted or changed yet.");
-                return CommandLine.ExitCode.SOFTWARE;
-            }
-
-            // Step 1: Update dist.apache.org. This is the only repository-dependent step, so it runs *before*
-            // promote (which drops the repository); everything after promote is repository-independent and thus
-            // resumable by --release. (PMC members only; auto-detected.)
-            if (isPmcMember) {
-                LOGGER.info("--- Step 1/5: Update dist.apache.org ---");
-                if (repository == null) {
-                    LOGGER.info("SKIPPED (staging repository already promoted; if dist still needs updating a PMC"
-                            + " member must run update-dist separately)");
-                } else {
-                    stepUpdateDist(repository, mode);
-                }
-            } else {
-                LOGGER.info("--- Step 1/5: Update dist.apache.org --- SKIPPED (current user is not a PMC member;"
-                        + " a PMC member must update dist.apache.org separately) ---");
-            }
-
-            // Step 2: Promote to Maven Central
-            LOGGER.info("--- Step 2/5: Promote to Maven Central ---");
-            if (repository == null) {
-                LOGGER.info("SKIPPED (staging repository already promoted and dropped)");
-            } else if (mode == ExecutionMode.DRY_RUN) {
-                LOGGER.info("Would promote {} to Maven Central", repository.getRepositoryId());
-            } else {
-                LOGGER.info("Promoting {}...", repository.getRepositoryId());
-                repositoryService.promote(repository);
-                LOGGER.info("Promoted. Artifacts will appear on Maven Central within ~10 minutes.");
-            }
-
-            // Step 3: Create next JIRA version and move unresolved issues (idempotent: skips if the successor
-            // already exists / there are no unresolved issues left to move)
-            LOGGER.info("--- Step 3/5: Create next JIRA version ---");
-            for (Release release : releases) {
-                stepCreateNextJiraVersion(release, mode);
-            }
-
-            // Step 4: Mark JIRA version as released (idempotent: release() skips an already-released version)
-            LOGGER.info("--- Step 4/5: Release JIRA version ---");
-            for (Release release : releases) {
-                stepReleaseJiraVersion(release, stagedAt, mode);
-            }
-
-            // Step 5: Update Apache Reporter (idempotent: skips releases the reporter already lists)
-            LOGGER.info("--- Step 5/5: Update Apache Reporter ---");
-            if (mode == ExecutionMode.DRY_RUN) {
-                LOGGER.info("Would add {} release(s) to the Apache Reporter System", releases.size());
-                releases.forEach(r -> LOGGER.info("  - {}", r.getFullName()));
-            } else {
-                stepUpdateReporter(releases);
-            }
-
-            LOGGER.info("=== Release finalization complete! ===");
+            return runFinalize(target, reusableCLIOptions.executionMode);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             LOGGER.warn("Failed executing command", e);
@@ -240,7 +144,126 @@ public class FinalizeCommand implements Command {
             LOGGER.warn("Failed executing command", e);
             return CommandLine.ExitCode.SOFTWARE;
         }
+    }
+
+    /**
+     * Resolves the target releases. Before promotion, act by {@code --repository} (which still exists); to
+     * resume after promotion (which drops the repository), act by {@code --release} name instead. Returns
+     * {@code null} (after logging the reason) when neither option resolves a target.
+     */
+    private FinalizeTarget resolveTarget() throws IOException {
+        if (repositoryId != null) {
+            StagingRepository repository;
+            try {
+                repository = repositoryService.find(repositoryId);
+            } catch (IllegalArgumentException e) {
+                LOGGER.error(
+                        "Staging repository {} was not found — it was most likely already promoted and"
+                                + " dropped. Resume the remaining steps with --release \"<name>\" instead of"
+                                + " --repository.",
+                        repositoryId);
+                return null;
+            }
+            return new FinalizeTarget(repository, repositoryService.getReleases(repository));
+        }
+        if (releaseName != null && !releaseName.isBlank()) {
+            return new FinalizeTarget(null, Set.copyOf(Release.fromString(releaseName)));
+        }
+        LOGGER.error("Provide either --repository <id> (initial run) or --release \"<name>\" (to resume after"
+                + " the staging repository has been promoted).");
+        return null;
+    }
+
+    /** Runs the pre-flight check and the five finalize steps for an already-resolved, non-empty target. */
+    private Integer runFinalize(FinalizeTarget target, ExecutionMode mode) throws Exception {
+        StagingRepository repository = target.repository();
+        Set<Release> releases = target.releases();
+        boolean isPmcMember = membersFinder.getCurrentMember().isPMCMember();
+        Instant stagedAt = repository != null ? repository.getCreated() : null;
+
+        String releaseNames = releases.stream()
+                .map(Release::getFullName)
+                .reduce((a, b) -> a + ", " + b)
+                .orElse("(none)");
+        LOGGER.info("=== Finalizing: {} ===", releaseNames);
+        if (repository == null) {
+            LOGGER.info("Resuming by release name; steps already completed before promotion are detected and"
+                    + " skipped.");
+        }
+
+        // Pre-flight: validate JIRA state *before* any irreversible action. Promoting to Maven Central drops
+        // the staging repository, so detecting a mis-tagged issue here lets the operator fix JIRA and re-run
+        // with nothing promoted or changed yet (SLING-13260). On a resume-by-name run there is no staging
+        // timestamp, so this is a no-op — it already passed on the initial run.
+        LOGGER.info("--- Pre-flight: validating JIRA state ---");
+        if (!preflightJiraState(releases, stagedAt)) {
+            LOGGER.error("Aborting finalize before any changes are made. Re-tag the issue(s) to the correct fix"
+                    + " version (or re-run with --force-close-late-issues), then run finalize again — nothing has"
+                    + " been promoted or changed yet.");
+            return CommandLine.ExitCode.SOFTWARE;
+        }
+
+        // Step 1: Update dist.apache.org. This is the only repository-dependent step, so it runs *before*
+        // promote (which drops the repository); everything after promote is repository-independent and thus
+        // resumable by --release. (PMC members only; auto-detected.)
+        stepUpdateDistStage(repository, mode, isPmcMember);
+
+        // Step 2: Promote to Maven Central
+        stepPromoteStage(repository, mode);
+
+        // Step 3: Create next JIRA version and move unresolved issues (idempotent: skips if the successor
+        // already exists / there are no unresolved issues left to move)
+        LOGGER.info("--- Step 3/5: Create next JIRA version ---");
+        for (Release release : releases) {
+            stepCreateNextJiraVersion(release, mode);
+        }
+
+        // Step 4: Mark JIRA version as released (idempotent: release() skips an already-released version)
+        LOGGER.info("--- Step 4/5: Release JIRA version ---");
+        for (Release release : releases) {
+            stepReleaseJiraVersion(release, stagedAt, mode);
+        }
+
+        // Step 5: Update Apache Reporter (idempotent: skips releases the reporter already lists)
+        LOGGER.info("--- Step 5/5: Update Apache Reporter ---");
+        if (mode == ExecutionMode.DRY_RUN) {
+            LOGGER.info("Would add {} release(s) to the Apache Reporter System", releases.size());
+            releases.forEach(r -> LOGGER.info("  - {}", r.getFullName()));
+        } else {
+            stepUpdateReporter(releases);
+        }
+
+        LOGGER.info("=== Release finalization complete! ===");
         return CommandLine.ExitCode.OK;
+    }
+
+    private void stepUpdateDistStage(StagingRepository repository, ExecutionMode mode, boolean isPmcMember)
+            throws IOException {
+        if (!isPmcMember) {
+            LOGGER.info("--- Step 1/5: Update dist.apache.org --- SKIPPED (current user is not a PMC member;"
+                    + " a PMC member must update dist.apache.org separately) ---");
+            return;
+        }
+        LOGGER.info("--- Step 1/5: Update dist.apache.org ---");
+        if (repository == null) {
+            LOGGER.info("SKIPPED (staging repository already promoted; if dist still needs updating a PMC"
+                    + " member must run update-dist separately)");
+        } else {
+            stepUpdateDist(repository, mode);
+        }
+    }
+
+    private void stepPromoteStage(StagingRepository repository, ExecutionMode mode) throws IOException {
+        LOGGER.info("--- Step 2/5: Promote to Maven Central ---");
+        if (repository == null) {
+            LOGGER.info("SKIPPED (staging repository already promoted and dropped)");
+        } else if (mode == ExecutionMode.DRY_RUN) {
+            LOGGER.info("Would promote {} to Maven Central", repository.getRepositoryId());
+        } else {
+            LOGGER.info("Promoting {}...", repository.getRepositoryId());
+            repositoryService.promote(repository);
+            LOGGER.info("Promoted. Artifacts will appear on Maven Central within ~10 minutes.");
+        }
     }
 
     private void stepUpdateDist(StagingRepository repository, ExecutionMode mode) throws IOException {
@@ -318,7 +341,7 @@ public class FinalizeCommand implements Command {
             // Query first so a resumed run does not add a release the reporter already lists.
             Set<String> alreadyRecorded = Reporter.fetchRegisteredReleaseNames(client);
             for (Release release : releases) {
-                if (alreadyRecorded != null && alreadyRecorded.contains(release.getFullName())) {
+                if (alreadyRecorded.contains(release.getFullName())) {
                     LOGGER.info("Apache Reporter already lists {}; skipping.", release.getFullName());
                     continue;
                 }

--- a/src/main/java/org/apache/sling/cli/impl/release/FinalizeCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/FinalizeCommand.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.cli.impl.release;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.sling.cli.impl.Command;
+import org.apache.sling.cli.impl.Credentials;
+import org.apache.sling.cli.impl.CredentialsService;
+import org.apache.sling.cli.impl.ExecutionMode;
+import org.apache.sling.cli.impl.http.HttpClientFactory;
+import org.apache.sling.cli.impl.jira.Issue;
+import org.apache.sling.cli.impl.jira.Version;
+import org.apache.sling.cli.impl.jira.VersionClient;
+import org.apache.sling.cli.impl.nexus.Artifact;
+import org.apache.sling.cli.impl.nexus.LocalRepository;
+import org.apache.sling.cli.impl.nexus.RepositoryService;
+import org.apache.sling.cli.impl.nexus.StagingRepository;
+import org.apache.sling.cli.impl.people.MembersFinder;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+/**
+ * Runs all post-vote release finalization steps in sequence:
+ * <ol>
+ *   <li>Promote staging repository to Maven Central</li>
+ *   <li>Upload artifacts to dist.apache.org (only when the current user is a PMC member)</li>
+ *   <li>Create the next JIRA version and move unresolved issues</li>
+ *   <li>Mark the current JIRA version as released</li>
+ *   <li>Update the Apache Reporter System</li>
+ * </ol>
+ * Uploading to dist.apache.org is only possible for PMC members, so it is performed automatically
+ * when the current user (resolved from the ASF credentials) is a PMC member and skipped otherwise.
+ * When skipped, a PMC member must complete it separately (the {@code tally-votes} result email asks
+ * for this when run by a non-PMC member). The previous version to remove from dist/release is
+ * deduced from the current contents of the release directory.
+ */
+@Component(
+        service = Command.class,
+        property = {
+            Command.PROPERTY_NAME_COMMAND_GROUP + "=" + FinalizeCommand.GROUP,
+            Command.PROPERTY_NAME_COMMAND_NAME + "=" + FinalizeCommand.NAME
+        })
+@CommandLine.Command(
+        name = FinalizeCommand.NAME,
+        description =
+                "Runs all post-vote finalization steps: promote to Maven Central, update JIRA, and report to Apache."
+                        + " When the current user is a PMC member, dist.apache.org is updated as well.",
+        subcommands = CommandLine.HelpCommand.class)
+public class FinalizeCommand implements Command {
+
+    static final String GROUP = "release";
+    static final String NAME = "finalize";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FinalizeCommand.class);
+
+    @CommandLine.Option(
+            names = {"-r", "--repository"},
+            description = "Nexus staging repository id",
+            required = true)
+    private Integer repositoryId;
+
+    @CommandLine.Mixin
+    private ReusableCLIOptions reusableCLIOptions;
+
+    @Reference
+    private RepositoryService repositoryService;
+
+    @Reference
+    private VersionClient versionClient;
+
+    @Reference
+    private HttpClientFactory httpClientFactory;
+
+    @Reference
+    private CredentialsService credentialsService;
+
+    @Reference
+    private MembersFinder membersFinder;
+
+    @Override
+    public Integer call() {
+        try {
+            StagingRepository repository = repositoryService.find(repositoryId);
+            Set<Release> releases = repositoryService.getReleases(repository);
+            ExecutionMode mode = reusableCLIOptions.executionMode;
+            boolean isPmcMember = membersFinder.getCurrentMember().isPMCMember();
+
+            String releaseNames = releases.stream()
+                    .map(Release::getFullName)
+                    .reduce((a, b) -> a + ", " + b)
+                    .orElse("(none)");
+            LOGGER.info("=== Finalizing: {} ===", releaseNames);
+
+            // Step 1: Promote to Maven Central
+            LOGGER.info("--- Step 1/5: Promote to Maven Central ---");
+            if (mode == ExecutionMode.DRY_RUN) {
+                LOGGER.info("Would promote {} to Maven Central", repository.getRepositoryId());
+            } else {
+                LOGGER.info("Promoting {}...", repository.getRepositoryId());
+                repositoryService.promote(repository);
+                LOGGER.info("Promoted. Artifacts will appear on Maven Central within ~10 minutes.");
+            }
+
+            // Step 2: Update dist.apache.org (PMC members only; auto-detected)
+            if (isPmcMember) {
+                LOGGER.info("--- Step 2/5: Update dist.apache.org ---");
+                stepUpdateDist(repository, mode);
+            } else {
+                LOGGER.info("--- Step 2/5: Update dist.apache.org --- SKIPPED (current user is not a PMC member;"
+                        + " a PMC member must update dist.apache.org separately) ---");
+            }
+
+            // Step 3: Create next JIRA version and move unresolved issues
+            LOGGER.info("--- Step 3/5: Create next JIRA version ---");
+            for (Release release : releases) {
+                stepCreateNextJiraVersion(release, mode);
+            }
+
+            // Step 4: Mark JIRA version as released
+            LOGGER.info("--- Step 4/5: Release JIRA version ---");
+            for (Release release : releases) {
+                stepReleaseJiraVersion(release, mode);
+            }
+
+            // Step 5: Update Apache Reporter
+            LOGGER.info("--- Step 5/5: Update Apache Reporter ---");
+            if (mode == ExecutionMode.DRY_RUN) {
+                LOGGER.info("Would add {} release(s) to the Apache Reporter System", releases.size());
+                releases.forEach(r -> LOGGER.info("  - {}", r.getFullName()));
+            } else {
+                stepUpdateReporter(releases);
+            }
+
+            LOGGER.info("=== Release finalization complete! ===");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.warn("Failed executing command", e);
+            return CommandLine.ExitCode.SOFTWARE;
+        } catch (Exception e) {
+            LOGGER.warn("Failed executing command", e);
+            return CommandLine.ExitCode.SOFTWARE;
+        }
+        return CommandLine.ExitCode.OK;
+    }
+
+    private void stepUpdateDist(StagingRepository repository, ExecutionMode mode) throws IOException {
+        LocalRepository localRepository = repositoryService.download(repository);
+        Artifact primary = localRepository.getArtifacts().stream()
+                .filter(a -> "pom".equals(a.getType()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No POM artifact found"));
+
+        String artifactId = primary.getArtifactId();
+        String newVersion = primary.getVersion();
+
+        // Publish the staged artifacts (downloaded from Nexus) to dist/release; Maven releases never
+        // stage to dist/dev. The previous version to remove is deduced from the current dist/release.
+        List<Path> newFiles = UpdateDistCommand.collectDownloadedFiles(localRepository.getRootFolder());
+        List<String> oldFiles = UpdateDistCommand.listPreviousReleaseFiles(artifactId, newVersion, null);
+
+        if (newFiles.isEmpty()) {
+            LOGGER.warn("No artifacts were downloaded for {} {}; skipping dist update.", artifactId, newVersion);
+            return;
+        }
+
+        if (mode == ExecutionMode.DRY_RUN) {
+            LOGGER.info("Would publish {} file(s) to dist/release for {} {}", newFiles.size(), artifactId, newVersion);
+            LOGGER.info("Would remove {} old file(s) from dist/release", oldFiles.size());
+        } else {
+            Credentials creds = credentialsService.getAsfCredentials();
+            UpdateDistCommand.publishToDistRelease(artifactId, newVersion, newFiles, oldFiles, creds);
+        }
+    }
+
+    private void stepCreateNextJiraVersion(Release release, ExecutionMode mode) throws IOException {
+        Version successorVersion = versionClient.findSuccessorVersion(release);
+        if (successorVersion == null) {
+            Release next = release.next();
+            if (mode == ExecutionMode.DRY_RUN) {
+                LOGGER.info("Would create JIRA version {}", next.getName());
+            } else {
+                versionClient.create(next.getName());
+                LOGGER.info("Created JIRA version {}", next.getName());
+                successorVersion = versionClient.findSuccessorVersion(release);
+            }
+        } else {
+            LOGGER.info("Successor JIRA version {} already exists", successorVersion.getName());
+        }
+        if (successorVersion != null) {
+            List<Issue> unresolved = versionClient.findUnresolvedIssues(release);
+            if (!unresolved.isEmpty()) {
+                if (mode == ExecutionMode.DRY_RUN) {
+                    LOGGER.info(
+                            "Would move {} unresolved issue(s) from {} to {}",
+                            unresolved.size(),
+                            release.getName(),
+                            successorVersion.getName());
+                } else {
+                    versionClient.moveIssuesToNewVersion(versionClient.find(release), successorVersion, unresolved);
+                    LOGGER.info("Moved {} unresolved issue(s) to {}", unresolved.size(), successorVersion.getName());
+                }
+            }
+        }
+    }
+
+    private void stepReleaseJiraVersion(Release release, ExecutionMode mode) throws Exception {
+        if (mode == ExecutionMode.DRY_RUN) {
+            LOGGER.info("Would mark JIRA version {} as released", release.getFullName());
+        } else {
+            versionClient.release(release);
+            LOGGER.info("Marked JIRA version {} as released", release.getFullName());
+        }
+    }
+
+    private void stepUpdateReporter(Set<Release> releases) throws IOException {
+        try (CloseableHttpClient client = httpClientFactory.newClient()) {
+            Instant now = Instant.now();
+            String xdate = DateTimeFormatter.ISO_LOCAL_DATE
+                    .withZone(ZoneId.systemDefault())
+                    .format(now);
+            for (Release release : releases) {
+                HttpPost post = new HttpPost("https://reporter.apache.org/addrelease.py");
+                List<NameValuePair> params = new ArrayList<>();
+                params.add(new BasicNameValuePair("date", Long.toString(now.getEpochSecond())));
+                params.add(new BasicNameValuePair("committee", "sling"));
+                params.add(new BasicNameValuePair("version", release.getFullName()));
+                params.add(new BasicNameValuePair("xdate", xdate));
+                post.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
+                try (CloseableHttpResponse response = client.execute(post)) {
+                    if (response.getStatusLine().getStatusCode() != 200) {
+                        throw new IOException("Reporter update failed for " + release.getFullName() + ": HTTP "
+                                + response.getStatusLine().getStatusCode());
+                    }
+                }
+                LOGGER.info("Updated Apache Reporter for {}", release.getFullName());
+            }
+        }
+    }
+}

--- a/src/main/java/org/apache/sling/cli/impl/release/FinalizeCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/FinalizeCommand.java
@@ -19,6 +19,7 @@
 package org.apache.sling.cli.impl.release;
 
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -28,9 +29,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicNameValuePair;
@@ -54,14 +58,25 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 /**
- * Runs all post-vote release finalization steps in sequence:
+ * Runs all post-vote release finalization steps in sequence. A read-only pre-flight first validates the
+ * JIRA state and aborts <em>before</em> any irreversible action if an issue was tagged with the release's
+ * fix version only after the artifacts were staged (it cannot be part of the release &mdash; SLING-13260);
+ * because nothing has run yet, the operator can fix the tagging in JIRA and simply re-run finalize. The
+ * steps are then:
  * <ol>
- *   <li>Promote staging repository to Maven Central</li>
  *   <li>Upload artifacts to dist.apache.org (only when the current user is a PMC member)</li>
+ *   <li>Promote staging repository to Maven Central</li>
  *   <li>Create the next JIRA version and move unresolved issues</li>
  *   <li>Mark the current JIRA version as released</li>
  *   <li>Update the Apache Reporter System</li>
  * </ol>
+ * The only repository-dependent step (dist.apache.org) runs <em>before</em> promotion, which drops the
+ * staging repository; every later step is repository-independent. This makes finalize <em>resumable</em>:
+ * if it fails partway (e.g. a JIRA hiccup), fix the problem and re-run. Before promotion, resume with
+ * {@code --repository}; after promotion the repository is gone, so resume with {@code --release "<name>"}.
+ * Each step detects whether it is already done (dist already published, repository already promoted, JIRA
+ * version already released, reporter already lists the release) and skips it, so re-running is safe.
+ * <p>
  * Uploading to dist.apache.org is only possible for PMC members, so it is performed automatically
  * when the current user (resolved from the ASF credentials) is a PMC member and skipped otherwise.
  * When skipped, a PMC member must complete it separately (the {@code tally-votes} result email asks
@@ -87,11 +102,27 @@ public class FinalizeCommand implements Command {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FinalizeCommand.class);
 
+    private static final String REPORTER_OVERVIEW_URL = "https://reporter.apache.org/api/overview?sling";
+    private static final String REPORTER_COMMITTEE = "sling";
+
     @CommandLine.Option(
             names = {"-r", "--repository"},
-            description = "Nexus staging repository id",
-            required = true)
+            description = "Nexus staging repository id (initial run, before promotion)")
     private Integer repositoryId;
+
+    @CommandLine.Option(
+            names = {"--release"},
+            description = "Release name(s) to resume by, e.g. \"Apache Sling Foo 1.2.0\" (comma-separated). Use to"
+                    + " resume finalize after the staging repository has been promoted and dropped; completed steps"
+                    + " are detected and skipped.")
+    private String releaseName;
+
+    @CommandLine.Option(
+            names = {"--force-close-late-issues"},
+            description = "Close issues even if they were tagged with the release's fix version only after the"
+                    + " artifacts were staged. Use only after confirming the fix is actually part of the release"
+                    + " (e.g. the fix version was simply forgotten during the release).")
+    private boolean forceCloseLateIssues;
 
     @CommandLine.Mixin
     private ReusableCLIOptions reusableCLIOptions;
@@ -114,20 +145,84 @@ public class FinalizeCommand implements Command {
     @Override
     public Integer call() {
         try {
-            StagingRepository repository = repositoryService.find(repositoryId);
-            Set<Release> releases = repositoryService.getReleases(repository);
             ExecutionMode mode = reusableCLIOptions.executionMode;
             boolean isPmcMember = membersFinder.getCurrentMember().isPMCMember();
+
+            // Resolve the target releases. Before promotion, act by --repository (which still exists);
+            // to resume after promotion (which drops the repository), act by --release name instead.
+            StagingRepository repository;
+            Set<Release> releases;
+            if (repositoryId != null) {
+                try {
+                    repository = repositoryService.find(repositoryId);
+                } catch (IllegalArgumentException e) {
+                    LOGGER.error(
+                            "Staging repository {} was not found — it was most likely already promoted and"
+                                    + " dropped. Resume the remaining steps with --release \"<name>\" instead of"
+                                    + " --repository.",
+                            repositoryId);
+                    return CommandLine.ExitCode.USAGE;
+                }
+                releases = repositoryService.getReleases(repository);
+            } else if (releaseName != null && !releaseName.isBlank()) {
+                repository = null;
+                releases = Set.copyOf(Release.fromString(releaseName));
+            } else {
+                LOGGER.error("Provide either --repository <id> (initial run) or --release \"<name>\" (to resume after"
+                        + " the staging repository has been promoted).");
+                return CommandLine.ExitCode.USAGE;
+            }
+
+            if (releases.isEmpty()) {
+                LOGGER.error("No releases could be resolved.");
+                return CommandLine.ExitCode.USAGE;
+            }
+
+            Instant stagedAt = repository != null ? repository.getCreated() : null;
 
             String releaseNames = releases.stream()
                     .map(Release::getFullName)
                     .reduce((a, b) -> a + ", " + b)
                     .orElse("(none)");
             LOGGER.info("=== Finalizing: {} ===", releaseNames);
+            if (repository == null) {
+                LOGGER.info("Resuming by release name; steps already completed before promotion are detected and"
+                        + " skipped.");
+            }
 
-            // Step 1: Promote to Maven Central
-            LOGGER.info("--- Step 1/5: Promote to Maven Central ---");
-            if (mode == ExecutionMode.DRY_RUN) {
+            // Pre-flight: validate JIRA state *before* any irreversible action. Promoting to Maven Central drops
+            // the staging repository, so detecting a mis-tagged issue here lets the operator fix JIRA and re-run
+            // with nothing promoted or changed yet (SLING-13260). On a resume-by-name run there is no staging
+            // timestamp, so this is a no-op — it already passed on the initial run.
+            LOGGER.info("--- Pre-flight: validating JIRA state ---");
+            if (!preflightJiraState(releases, stagedAt)) {
+                LOGGER.error("Aborting finalize before any changes are made. Re-tag the issue(s) to the correct fix"
+                        + " version (or re-run with --force-close-late-issues), then run finalize again — nothing has"
+                        + " been promoted or changed yet.");
+                return CommandLine.ExitCode.SOFTWARE;
+            }
+
+            // Step 1: Update dist.apache.org. This is the only repository-dependent step, so it runs *before*
+            // promote (which drops the repository); everything after promote is repository-independent and thus
+            // resumable by --release. (PMC members only; auto-detected.)
+            if (isPmcMember) {
+                LOGGER.info("--- Step 1/5: Update dist.apache.org ---");
+                if (repository == null) {
+                    LOGGER.info("SKIPPED (staging repository already promoted; if dist still needs updating a PMC"
+                            + " member must run update-dist separately)");
+                } else {
+                    stepUpdateDist(repository, mode);
+                }
+            } else {
+                LOGGER.info("--- Step 1/5: Update dist.apache.org --- SKIPPED (current user is not a PMC member;"
+                        + " a PMC member must update dist.apache.org separately) ---");
+            }
+
+            // Step 2: Promote to Maven Central
+            LOGGER.info("--- Step 2/5: Promote to Maven Central ---");
+            if (repository == null) {
+                LOGGER.info("SKIPPED (staging repository already promoted and dropped)");
+            } else if (mode == ExecutionMode.DRY_RUN) {
                 LOGGER.info("Would promote {} to Maven Central", repository.getRepositoryId());
             } else {
                 LOGGER.info("Promoting {}...", repository.getRepositoryId());
@@ -135,28 +230,20 @@ public class FinalizeCommand implements Command {
                 LOGGER.info("Promoted. Artifacts will appear on Maven Central within ~10 minutes.");
             }
 
-            // Step 2: Update dist.apache.org (PMC members only; auto-detected)
-            if (isPmcMember) {
-                LOGGER.info("--- Step 2/5: Update dist.apache.org ---");
-                stepUpdateDist(repository, mode);
-            } else {
-                LOGGER.info("--- Step 2/5: Update dist.apache.org --- SKIPPED (current user is not a PMC member;"
-                        + " a PMC member must update dist.apache.org separately) ---");
-            }
-
-            // Step 3: Create next JIRA version and move unresolved issues
+            // Step 3: Create next JIRA version and move unresolved issues (idempotent: skips if the successor
+            // already exists / there are no unresolved issues left to move)
             LOGGER.info("--- Step 3/5: Create next JIRA version ---");
             for (Release release : releases) {
                 stepCreateNextJiraVersion(release, mode);
             }
 
-            // Step 4: Mark JIRA version as released
+            // Step 4: Mark JIRA version as released (idempotent: release() skips an already-released version)
             LOGGER.info("--- Step 4/5: Release JIRA version ---");
             for (Release release : releases) {
-                stepReleaseJiraVersion(release, mode);
+                stepReleaseJiraVersion(release, stagedAt, mode);
             }
 
-            // Step 5: Update Apache Reporter
+            // Step 5: Update Apache Reporter (idempotent: skips releases the reporter already lists)
             LOGGER.info("--- Step 5/5: Update Apache Reporter ---");
             if (mode == ExecutionMode.DRY_RUN) {
                 LOGGER.info("Would add {} release(s) to the Apache Reporter System", releases.size());
@@ -186,6 +273,11 @@ public class FinalizeCommand implements Command {
 
         String artifactId = primary.getArtifactId();
         String newVersion = primary.getVersion();
+
+        if (UpdateDistCommand.isVersionPublished(artifactId, newVersion)) {
+            LOGGER.info("dist/release already contains {} {}; skipping.", artifactId, newVersion);
+            return;
+        }
 
         // Publish the staged artifacts (downloaded from Nexus) to dist/release; Maven releases never
         // stage to dist/dev. The previous version to remove is deduced from the current dist/release.
@@ -237,26 +329,54 @@ public class FinalizeCommand implements Command {
         }
     }
 
-    private void stepReleaseJiraVersion(Release release, ExecutionMode mode) throws Exception {
+    /**
+     * Validates, before any irreversible action, that no resolved issue acquired a release's fix version
+     * only after the artifacts were staged. Logs any offenders.
+     *
+     * @return {@code true} if finalize may proceed, {@code false} if it must abort
+     */
+    private boolean preflightJiraState(Set<Release> releases, Instant stagedAt) throws IOException {
+        boolean ok = true;
+        for (Release release : releases) {
+            List<Issue> lateIssues = LateFixVersionGuard.reportLateIssues(
+                    versionClient, release, stagedAt, forceCloseLateIssues, LOGGER);
+            if (!lateIssues.isEmpty() && !forceCloseLateIssues) {
+                ok = false;
+            }
+        }
+        if (ok) {
+            LOGGER.info("JIRA state OK.");
+        }
+        return ok;
+    }
+
+    private void stepReleaseJiraVersion(Release release, Instant stagedAt, ExecutionMode mode) throws Exception {
         if (mode == ExecutionMode.DRY_RUN) {
             LOGGER.info("Would mark JIRA version {} as released", release.getFullName());
         } else {
-            versionClient.release(release);
+            // pre-flight already validated this; when forcing, also skip the guard inside release()
+            versionClient.release(release, forceCloseLateIssues ? null : stagedAt);
             LOGGER.info("Marked JIRA version {} as released", release.getFullName());
         }
     }
 
     private void stepUpdateReporter(Set<Release> releases) throws IOException {
         try (CloseableHttpClient client = httpClientFactory.newClient()) {
+            // Query first so a resumed run does not add a release the reporter already lists.
+            Set<String> alreadyRecorded = fetchRecordedReporterReleases(client);
             Instant now = Instant.now();
             String xdate = DateTimeFormatter.ISO_LOCAL_DATE
                     .withZone(ZoneId.systemDefault())
                     .format(now);
             for (Release release : releases) {
+                if (alreadyRecorded != null && alreadyRecorded.contains(release.getFullName())) {
+                    LOGGER.info("Apache Reporter already lists {}; skipping.", release.getFullName());
+                    continue;
+                }
                 HttpPost post = new HttpPost("https://reporter.apache.org/addrelease.py");
                 List<NameValuePair> params = new ArrayList<>();
                 params.add(new BasicNameValuePair("date", Long.toString(now.getEpochSecond())));
-                params.add(new BasicNameValuePair("committee", "sling"));
+                params.add(new BasicNameValuePair("committee", REPORTER_COMMITTEE));
                 params.add(new BasicNameValuePair("version", release.getFullName()));
                 params.add(new BasicNameValuePair("xdate", xdate));
                 post.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
@@ -268,6 +388,34 @@ public class FinalizeCommand implements Command {
                 }
                 LOGGER.info("Updated Apache Reporter for {}", release.getFullName());
             }
+        }
+    }
+
+    /**
+     * Fetches the set of release names the Apache Reporter already records for the Sling committee, so a
+     * resumed run can skip re-adding them. Returns {@code null} if the reporter could not be queried, in
+     * which case the caller should post without deduplication rather than risk skipping a real release.
+     */
+    private Set<String> fetchRecordedReporterReleases(CloseableHttpClient client) {
+        HttpGet get = new HttpGet(REPORTER_OVERVIEW_URL);
+        get.setHeader("Accept", "application/json");
+        try (CloseableHttpResponse response = client.execute(get)) {
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != 200 || response.getEntity() == null) {
+                LOGGER.warn("Could not query Apache Reporter (HTTP {}); will post without deduplication.", statusCode);
+                return null;
+            }
+            try (InputStreamReader reader =
+                    new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8)) {
+                JsonObject root = new Gson().fromJson(reader, JsonObject.class);
+                JsonObject releases = root == null ? null : root.getAsJsonObject("releases");
+                JsonObject committeeReleases = releases == null ? null : releases.getAsJsonObject(REPORTER_COMMITTEE);
+                // the reporter keys each release by its full name (e.g. "Apache Sling API 2.27.6")
+                return committeeReleases == null ? Set.of() : Set.copyOf(committeeReleases.keySet());
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Could not query Apache Reporter ({}); will post without deduplication.", e.getMessage());
+            return null;
         }
     }
 }

--- a/src/main/java/org/apache/sling/cli/impl/release/JiraVersions.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/JiraVersions.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.cli.impl.release;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.sling.cli.impl.ExecutionMode;
+import org.apache.sling.cli.impl.InputOption;
+import org.apache.sling.cli.impl.UserInput;
+import org.apache.sling.cli.impl.jira.Issue;
+import org.apache.sling.cli.impl.jira.Version;
+import org.apache.sling.cli.impl.jira.VersionClient;
+import org.slf4j.Logger;
+
+/**
+ * Shared JIRA version housekeeping for the post-vote commands, so {@link CreateJiraVersionCommand} and
+ * {@link FinalizeCommand} do not duplicate it: ensure the successor version exists and move any
+ * still-unresolved issues from the released version to it.
+ */
+final class JiraVersions {
+
+    private JiraVersions() {}
+
+    /**
+     * Ensures the successor of {@code release} exists (creating it when necessary) and moves the released
+     * version's still-unresolved issues to it. Honours the execution {@code mode}: {@code DRY_RUN}
+     * describes the actions, {@code INTERACTIVE} confirms each one, {@code AUTO} performs them. Both
+     * operations are idempotent, so this is safe to re-run.
+     */
+    static void createSuccessorAndMoveUnresolved(
+            VersionClient versionClient, Release release, ExecutionMode mode, Logger logger) throws IOException {
+        Version successorVersion = versionClient.findSuccessorVersion(release);
+        if (successorVersion == null) {
+            Release next = release.next();
+            if (confirm(
+                    mode,
+                    logger,
+                    "Would create JIRA version " + next.getName(),
+                    "Should version %s be created?",
+                    next.getName())) {
+                versionClient.create(next.getName());
+                logger.info("Created JIRA version {}", next.getName());
+                successorVersion = versionClient.findSuccessorVersion(release);
+            }
+        } else {
+            logger.info("Successor JIRA version {} already exists", successorVersion.getName());
+        }
+        if (successorVersion != null) {
+            List<Issue> unresolved = versionClient.findUnresolvedIssues(release);
+            if (!unresolved.isEmpty()
+                    && confirm(
+                            mode,
+                            logger,
+                            String.format(
+                                    "Would move %d unresolved issue(s) from %s to %s",
+                                    unresolved.size(), release.getName(), successorVersion.getName()),
+                            "Should the %d unresolved issue(s) from %s be moved to %s?",
+                            unresolved.size(),
+                            release.getName(),
+                            successorVersion.getName())) {
+                versionClient.moveIssuesToNewVersion(versionClient.find(release), successorVersion, unresolved);
+                logger.info("Moved {} unresolved issue(s) to {}", unresolved.size(), successorVersion.getName());
+            }
+        }
+    }
+
+    /**
+     * Decides whether to perform an action for the given mode: in {@code DRY_RUN} logs {@code dryRunMessage}
+     * and returns {@code false}; in {@code INTERACTIVE} asks the {@code questionFormat} question; in
+     * {@code AUTO} returns {@code true}.
+     */
+    private static boolean confirm(
+            ExecutionMode mode, Logger logger, String dryRunMessage, String questionFormat, Object... questionArgs) {
+        switch (mode) {
+            case DRY_RUN:
+                logger.info(dryRunMessage);
+                return false;
+            case INTERACTIVE:
+                return UserInput.yesNo(String.format(questionFormat, questionArgs), InputOption.YES) == InputOption.YES;
+            case AUTO:
+            default:
+                return true;
+        }
+    }
+}

--- a/src/main/java/org/apache/sling/cli/impl/release/LateFixVersionGuard.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/LateFixVersionGuard.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.cli.impl.release;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+
+import org.apache.sling.cli.impl.jira.Issue;
+import org.apache.sling.cli.impl.jira.VersionClient;
+import org.slf4j.Logger;
+
+/**
+ * Shared logic for the post-vote commands that close a JIRA version's fixed issues. Detects issues
+ * that acquired the release's fix version only <em>after</em> the release artifacts were staged &mdash;
+ * such issues cannot be part of the release and closing them under it is wrong (see SLING-13260).
+ */
+final class LateFixVersionGuard {
+
+    private LateFixVersionGuard() {}
+
+    /**
+     * Finds issues tagged with the release's fix version after {@code stagedAt} and logs them, phrasing
+     * the message according to whether the operator chose to override the guard.
+     *
+     * @param versionClient the JIRA client
+     * @param release the release being closed
+     * @param stagedAt the moment the artifacts were staged, or {@code null} when it is unknown (e.g. the
+     *     staging repository no longer exists), in which case the check is skipped
+     * @param force whether the operator passed {@code --force-close-late-issues}
+     * @param logger the caller's logger, so messages are attributed to the running command
+     * @return the offending issues, never {@code null}
+     * @throws IOException in case of any errors talking to JIRA
+     */
+    static List<Issue> reportLateIssues(
+            VersionClient versionClient, Release release, Instant stagedAt, boolean force, Logger logger)
+            throws IOException {
+        List<Issue> late = stagedAt == null ? List.of() : versionClient.findIssuesFixVersionedAfter(release, stagedAt);
+        if (late.isEmpty()) {
+            return late;
+        }
+        if (force) {
+            logger.warn(
+                    "{} issue(s) acquired fix version \"{}\" after the artifacts were staged ({}); closing them"
+                            + " anyway because --force-close-late-issues was given:",
+                    late.size(),
+                    release.getName(),
+                    stagedAt);
+        } else {
+            logger.warn(
+                    "Refusing to release JIRA version {}: the following issue(s) acquired this fix version after the"
+                            + " artifacts were staged ({}) and cannot be part of the release. Re-tag them to the"
+                            + " correct fix version, or pass --force-close-late-issues to close them anyway:",
+                    release.getFullName(),
+                    stagedAt);
+        }
+        late.forEach(issue -> logger.warn("  - {} ({})", issue.getKey(), issue.getSummary()));
+        return late;
+    }
+}

--- a/src/main/java/org/apache/sling/cli/impl/release/ReleaseJiraVersionCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/ReleaseJiraVersionCommand.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sling.cli.impl.release;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
@@ -64,6 +65,14 @@ public class ReleaseJiraVersionCommand extends AbstractReleaseCommand {
     @CommandLine.Mixin
     private ReusableCLIOptions reusableCLIOptions;
 
+    @CommandLine.Option(
+            names = {"--force-close-late-issues"},
+            description = "Close issues even if they were tagged with the release's fix version only after the"
+                    + " artifacts were staged. Use only after confirming the fix is actually part of the release"
+                    + " (e.g. the fix version was simply forgotten during the release). Only has an effect when"
+                    + " --repository is used, since the staging timestamp is unavailable once the repository is gone.")
+    private boolean forceCloseLateIssues;
+
     @Override
     public Integer call() {
         try {
@@ -72,6 +81,10 @@ public class ReleaseJiraVersionCommand extends AbstractReleaseCommand {
                 LOGGER.error("Provide either --repository or --release.");
                 return CommandLine.ExitCode.USAGE;
             }
+            // The staging timestamp is only available while the staging repository still exists (i.e. when
+            // acting by --repository). Acting by --release happens after promotion, when it is gone.
+            Instant stagedAt =
+                    repositoryId != null ? repositoryService.find(repositoryId).getCreated() : null;
             ExecutionMode executionMode = reusableCLIOptions.executionMode;
             LOGGER.info(
                     "The following Jira versions {} be released:{}",
@@ -87,6 +100,7 @@ public class ReleaseJiraVersionCommand extends AbstractReleaseCommand {
                         issue.getStatus(),
                         issue.getResolution()));
                 LOGGER.info("");
+                LateFixVersionGuard.reportLateIssues(versionClient, release, stagedAt, forceCloseLateIssues, LOGGER);
                 boolean shouldRelease = false;
                 if (executionMode == ExecutionMode.INTERACTIVE) {
                     InputOption answer = UserInput.yesNo(
@@ -96,7 +110,8 @@ public class ReleaseJiraVersionCommand extends AbstractReleaseCommand {
                     shouldRelease = true;
                 }
                 if (shouldRelease) {
-                    versionClient.release(release);
+                    // when forcing, skip the guard inside release() by not passing the staged-at timestamp
+                    versionClient.release(release, forceCloseLateIssues ? null : stagedAt);
                     LOGGER.info("{} was released:", release.getFullName());
                     fixedIssues = versionClient.findFixedIssues(release);
                     fixedIssues.forEach(issue -> LOGGER.info(

--- a/src/main/java/org/apache/sling/cli/impl/release/Reporter.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/Reporter.java
@@ -69,8 +69,9 @@ final class Reporter {
 
     /**
      * Returns the set of release names the reporter already records for the Sling committee, so callers
-     * can skip re-adding them. Returns {@code null} if the reporter could not be queried, in which case
-     * callers should proceed without deduplication rather than risk skipping a real release.
+     * can skip re-adding them. Returns an empty set if the reporter could not be queried; callers then
+     * deduplicate against nothing and proceed to (re-)add every release rather than risk skipping a real
+     * one.
      */
     static Set<String> fetchRegisteredReleaseNames(CloseableHttpClient client) {
         HttpGet get = new HttpGet(OVERVIEW_URL);
@@ -79,7 +80,7 @@ final class Reporter {
             int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode != 200 || response.getEntity() == null) {
                 LOGGER.warn("Could not query Apache Reporter (HTTP {}); will not deduplicate.", statusCode);
-                return null;
+                return Set.of();
             }
             try (InputStreamReader reader =
                     new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8)) {
@@ -91,7 +92,7 @@ final class Reporter {
             }
         } catch (Exception e) {
             LOGGER.warn("Could not query Apache Reporter ({}); will not deduplicate.", e.getMessage());
-            return null;
+            return Set.of();
         }
     }
 

--- a/src/main/java/org/apache/sling/cli/impl/release/Reporter.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/Reporter.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.cli.impl.release;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Shared access to the Apache Reporter System ({@code reporter.apache.org}) for recording releases.
+ *
+ * <p>Centralises the {@code addrelease.py} call so {@link UpdateReporterCommand} and
+ * {@link FinalizeCommand} do not duplicate it. Note that {@code addrelease.py} returns HTTP 200 even on
+ * failure, with the reason in the response body, so the body must be inspected to tell success from
+ * failure.</p>
+ */
+final class Reporter {
+
+    /** Outcome of an {@link #addRelease} call that did not raise a hard error. */
+    enum Result {
+        /** The release was recorded. */
+        ADDED,
+        /** The reporter rejected the write because the current user lacks committee access. */
+        ACCESS_DENIED
+    }
+
+    static final String COMMITTEE = "sling";
+    static final String OVERVIEW_URL = "https://reporter.apache.org/api/overview?" + COMMITTEE;
+    static final String ADD_RELEASE_URL = "https://reporter.apache.org/addrelease.py";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Reporter.class);
+
+    private Reporter() {}
+
+    /**
+     * Returns the set of release names the reporter already records for the Sling committee, so callers
+     * can skip re-adding them. Returns {@code null} if the reporter could not be queried, in which case
+     * callers should proceed without deduplication rather than risk skipping a real release.
+     */
+    static Set<String> fetchRegisteredReleaseNames(CloseableHttpClient client) {
+        HttpGet get = new HttpGet(OVERVIEW_URL);
+        get.setHeader("Accept", "application/json");
+        try (CloseableHttpResponse response = client.execute(get)) {
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != 200 || response.getEntity() == null) {
+                LOGGER.warn("Could not query Apache Reporter (HTTP {}); will not deduplicate.", statusCode);
+                return null;
+            }
+            try (InputStreamReader reader =
+                    new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8)) {
+                JsonObject root = new Gson().fromJson(reader, JsonObject.class);
+                JsonObject releases = root == null ? null : root.getAsJsonObject("releases");
+                JsonObject committeeReleases = releases == null ? null : releases.getAsJsonObject(COMMITTEE);
+                // the reporter keys each release by its full name (e.g. "Apache Sling API 2.27.6")
+                return committeeReleases == null ? Set.of() : Set.copyOf(committeeReleases.keySet());
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Could not query Apache Reporter ({}); will not deduplicate.", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Records a single release with the reporter, dated now.
+     *
+     * @return {@link Result#ADDED} on success, or {@link Result#ACCESS_DENIED} when the reporter rejects
+     *     the write for lack of committee access (a non-PMC / non-ASF-member user)
+     * @throws IOException on any other failure (including a non-200 status or an unexpected error body)
+     */
+    static Result addRelease(CloseableHttpClient client, Release release) throws IOException {
+        Instant now = Instant.now();
+        String xdate = DateTimeFormatter.ISO_LOCAL_DATE
+                .withZone(ZoneId.systemDefault())
+                .format(now);
+        HttpPost post = new HttpPost(ADD_RELEASE_URL);
+        List<NameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("date", Long.toString(now.getEpochSecond())));
+        params.add(new BasicNameValuePair("committee", COMMITTEE));
+        params.add(new BasicNameValuePair("version", release.getFullName()));
+        params.add(new BasicNameValuePair("xdate", xdate));
+        post.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
+
+        try (CloseableHttpResponse response = client.execute(post)) {
+            int statusCode = response.getStatusLine().getStatusCode();
+            // addrelease.py returns HTTP 200 even on failure, with the reason in the body.
+            String body = response.getEntity() == null
+                    ? ""
+                    : EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8)
+                            .strip();
+            if (statusCode == 200 && !body.contains("Could not save")) {
+                return Result.ADDED;
+            }
+            if (body.toLowerCase().contains("access to this committee data")) {
+                return Result.ACCESS_DENIED;
+            }
+            throw new IOException("Reporter update failed for " + release.getFullName() + ": HTTP " + statusCode
+                    + (body.isEmpty() ? "" : " - " + body));
+        }
+    }
+}

--- a/src/main/java/org/apache/sling/cli/impl/release/TallyVotesCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/TallyVotesCommand.java
@@ -195,20 +195,24 @@ public class TallyVotesCommand implements Command {
     }
 
     /**
-     * Builds the closing paragraph of the result email. PMC members copy the release to the dist
-     * directory themselves; non-PMC release managers can only promote to Maven Central and must ask
-     * a PMC member to handle the dist upload (which is restricted to PMC members). PMC membership is
-     * derived from the current user, so no flag is needed.
+     * Builds the closing paragraph of the result email. Finalizing a release means copying it to the
+     * dist directory first and only then promoting the artifacts to Maven Central. Because the dist
+     * upload is restricted to PMC members, a non-PMC release manager cannot perform the finalization
+     * in the correct order and must ask a PMC member to finalize the release. PMC membership is derived
+     * from the current user, so no flag is needed.
      */
     private String closingAction(String releaseFullName, boolean isPmcMember) {
         if (isPmcMember) {
             return "I will copy this release to the Sling dist directory and\n"
                     + "promote the artifacts to the central Maven repository.";
         }
-        return "I will promote the artifacts to the central Maven repository.\n\n"
-                + "As I am not a PMC member, I cannot copy the release to the dist directory myself.\n\n"
-                + "ACTION NEEDED: can a PMC member please copy " + releaseFullName
-                + " to the Sling dist directory (https://dist.apache.org/repos/dist/release/sling/)?";
+        return "The release still needs to be finalized: the artifacts must first be copied to the\n"
+                + "Sling dist directory (https://dist.apache.org/repos/dist/release/sling/) and only\n"
+                + "then promoted to the central Maven repository. As that first step requires PMC\n"
+                + "membership, which I do not have, I cannot finalize this release myself.\n\n"
+                + "ACTION NEEDED: can a PMC member please finalize " + releaseFullName + " by copying it\n"
+                + "to the dist directory and then promoting the staged artifacts to the central Maven\n"
+                + "repository?";
     }
 
     // TODO - better detection of '+1' votes

--- a/src/main/java/org/apache/sling/cli/impl/release/UpdateDistCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/UpdateDistCommand.java
@@ -312,6 +312,16 @@ public class UpdateDistCommand implements Command {
         }
     }
 
+    /**
+     * Returns {@code true} if {@code dist/release/sling} already contains files for the given
+     * {@code artifactId} and {@code version}. Used to make publishing idempotent so finalize can be
+     * safely re-run.
+     */
+    static boolean isVersionPublished(String artifactId, String version) throws IOException {
+        return listDistFiles(DIST_RELEASE_URL, artifactId + "-" + version).stream()
+                .anyMatch(f -> belongsToVersion(f, artifactId, version));
+    }
+
     private static boolean isVersionedArtifactFile(String fileName, String artifactId) {
         String prefix = artifactId + "-";
         return fileName.length() > prefix.length()

--- a/src/main/java/org/apache/sling/cli/impl/release/UpdateDistCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/UpdateDistCommand.java
@@ -37,6 +37,7 @@ import org.apache.sling.cli.impl.UserInput;
 import org.apache.sling.cli.impl.nexus.Artifact;
 import org.apache.sling.cli.impl.nexus.LocalRepository;
 import org.apache.sling.cli.impl.nexus.RepositoryService;
+import org.apache.sling.cli.impl.nexus.StagingRepository;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -111,18 +112,15 @@ public class UpdateDistCommand implements Command {
     @Override
     public Integer call() {
         try {
-            LocalRepository localRepository = repositoryService.download(repositoryService.find(repositoryId));
-            Artifact primary = localRepository.getArtifacts().stream()
-                    .filter(a -> "pom".equals(a.getType()))
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalStateException("No POM artifact found in staging repository"));
-            String artifactId = primary.getArtifactId();
-            String newVersion = primary.getVersion();
+            DistReleasePlan plan =
+                    planDistRelease(repositoryService, repositoryService.find(repositoryId), previousVersion);
 
-            List<Path> newFiles = collectDownloadedFiles(localRepository.getRootFolder());
-            List<String> oldFiles = listPreviousReleaseFiles(artifactId, newVersion, previousVersion);
-
-            if (newFiles.isEmpty()) {
+            if (plan.alreadyPublished()) {
+                LOGGER.info(
+                        "dist/release already contains {} {}; nothing to do.", plan.artifactId(), plan.newVersion());
+                return CommandLine.ExitCode.OK;
+            }
+            if (plan.newFiles().isEmpty()) {
                 LOGGER.warn("No artifacts were downloaded for staging repository {}.", repositoryId);
                 return CommandLine.ExitCode.USAGE;
             }
@@ -131,29 +129,43 @@ public class UpdateDistCommand implements Command {
                 case DRY_RUN:
                     LOGGER.info(
                             "Would publish {} file(s) to dist/release for {} {}:",
-                            newFiles.size(),
-                            artifactId,
-                            newVersion);
-                    newFiles.forEach(f -> LOGGER.info("  put {} -> {}{}", f, DIST_RELEASE_URL, f.getFileName()));
-                    if (!oldFiles.isEmpty()) {
-                        LOGGER.info("Would remove {} old file(s) from dist/release:", oldFiles.size());
-                        oldFiles.forEach(f -> LOGGER.info("  rm {}", DIST_RELEASE_URL + f));
+                            plan.newFiles().size(),
+                            plan.artifactId(),
+                            plan.newVersion());
+                    plan.newFiles().forEach(f -> LOGGER.info("  put {} -> {}{}", f, DIST_RELEASE_URL, f.getFileName()));
+                    if (!plan.oldFiles().isEmpty()) {
+                        LOGGER.info(
+                                "Would remove {} old file(s) from dist/release:",
+                                plan.oldFiles().size());
+                        plan.oldFiles().forEach(f -> LOGGER.info("  rm {}", DIST_RELEASE_URL + f));
                     }
                     break;
                 case INTERACTIVE:
                     String question = String.format(
                             "Publish %d file(s) for %s %s to dist/release and remove %d older file(s) for %s?",
-                            newFiles.size(), artifactId, newVersion, oldFiles.size(), artifactId);
+                            plan.newFiles().size(),
+                            plan.artifactId(),
+                            plan.newVersion(),
+                            plan.oldFiles().size(),
+                            plan.artifactId());
                     if (InputOption.YES.equals(UserInput.yesNo(question, InputOption.YES))) {
                         publishToDistRelease(
-                                artifactId, newVersion, newFiles, oldFiles, credentialsService.getAsfCredentials());
+                                plan.artifactId(),
+                                plan.newVersion(),
+                                plan.newFiles(),
+                                plan.oldFiles(),
+                                credentialsService.getAsfCredentials());
                     } else {
                         LOGGER.info("Aborted.");
                     }
                     break;
                 case AUTO:
                     publishToDistRelease(
-                            artifactId, newVersion, newFiles, oldFiles, credentialsService.getAsfCredentials());
+                            plan.artifactId(),
+                            plan.newVersion(),
+                            plan.newFiles(),
+                            plan.oldFiles(),
+                            credentialsService.getAsfCredentials());
                     break;
             }
         } catch (IOException e) {
@@ -161,6 +173,37 @@ public class UpdateDistCommand implements Command {
             return CommandLine.ExitCode.SOFTWARE;
         }
         return CommandLine.ExitCode.OK;
+    }
+
+    /** What to publish to and remove from dist/release for one staged release. */
+    record DistReleasePlan(
+            String artifactId,
+            String newVersion,
+            List<Path> newFiles,
+            List<String> oldFiles,
+            boolean alreadyPublished) {}
+
+    /**
+     * Downloads the staged artifacts and works out what to publish to and remove from {@code dist/release}.
+     * Shared by this command and {@link FinalizeCommand} so the flow is not duplicated. When the version is
+     * already present in {@code dist/release} the returned plan is marked {@link DistReleasePlan#alreadyPublished()}.
+     */
+    static DistReleasePlan planDistRelease(
+            RepositoryService repositoryService, StagingRepository repository, String previousVersion)
+            throws IOException {
+        LocalRepository localRepository = repositoryService.download(repository);
+        Artifact primary = localRepository.getArtifacts().stream()
+                .filter(a -> "pom".equals(a.getType()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No POM artifact found in staging repository"));
+        String artifactId = primary.getArtifactId();
+        String newVersion = primary.getVersion();
+        if (isVersionPublished(artifactId, newVersion)) {
+            return new DistReleasePlan(artifactId, newVersion, List.of(), List.of(), true);
+        }
+        List<Path> newFiles = collectDownloadedFiles(localRepository.getRootFolder());
+        List<String> oldFiles = listPreviousReleaseFiles(artifactId, newVersion, previousVersion);
+        return new DistReleasePlan(artifactId, newVersion, newFiles, oldFiles, false);
     }
 
     /**

--- a/src/main/java/org/apache/sling/cli/impl/release/UpdateReporterCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/UpdateReporterCommand.java
@@ -19,20 +19,9 @@
 package org.apache.sling.cli.impl.release;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
 import java.util.Set;
 
-import org.apache.http.NameValuePair;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.util.EntityUtils;
 import org.apache.sling.cli.impl.Command;
 import org.apache.sling.cli.impl.InputOption;
 import org.apache.sling.cli.impl.UserInput;
@@ -109,7 +98,7 @@ public class UpdateReporterCommand extends AbstractReleaseCommand {
             }
 
         } catch (IOException e) {
-            LOGGER.error(String.format("Unable to update reporter service; passed command: %s.", repositoryId), e);
+            LOGGER.error("Unable to update the Apache Reporter System.", e);
             return CommandLine.ExitCode.SOFTWARE;
         }
         return CommandLine.ExitCode.OK;
@@ -117,30 +106,18 @@ public class UpdateReporterCommand extends AbstractReleaseCommand {
 
     private void updateReporter(Set<Release> releases) throws IOException {
         try (CloseableHttpClient client = httpClientFactory.newClient()) {
+            Set<String> alreadyRecorded = Reporter.fetchRegisteredReleaseNames(client);
             for (Release release : releases) {
-                HttpPost post = new HttpPost("https://reporter.apache.org/addrelease.py");
-                SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
-                List<NameValuePair> parameters = new ArrayList<>();
-                Date now = new Date();
-                parameters.add(new BasicNameValuePair("date", Long.toString(now.getTime() / 1000)));
-                parameters.add(new BasicNameValuePair("committee", "sling"));
-                parameters.add(new BasicNameValuePair("version", release.getFullName()));
-                parameters.add(new BasicNameValuePair("xdate", simpleDateFormat.format(now)));
-                post.setEntity(new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8));
-                try (CloseableHttpResponse response = client.execute(post)) {
-                    int statusCode = response.getStatusLine().getStatusCode();
-                    // addrelease.py returns HTTP 200 even on failure, with the error in the body, so the
-                    // status code alone cannot tell success from failure.
-                    String body = response.getEntity() == null
-                            ? ""
-                            : EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8)
-                                    .strip();
-                    if (statusCode != 200 || body.contains("Could not save")) {
-                        throw new IOException(String.format(
-                                "The Apache Reporter System update failed for release %s. HTTP %s%s",
-                                release.getFullName(), statusCode, body.isEmpty() ? "" : " - " + body));
-                    }
+                if (alreadyRecorded != null && alreadyRecorded.contains(release.getFullName())) {
+                    LOGGER.info("Apache Reporter already lists {}; skipping.", release.getFullName());
+                    continue;
                 }
+                if (Reporter.addRelease(client, release) == Reporter.Result.ACCESS_DENIED) {
+                    throw new IOException("The Apache Reporter System update failed for release "
+                            + release.getFullName() + ": the current user lacks committee access (release data can"
+                            + " only be added by a Sling PMC member or an ASF member).");
+                }
+                LOGGER.info("Added {} to the Apache Reporter System.", release.getFullName());
             }
         }
     }

--- a/src/main/java/org/apache/sling/cli/impl/release/UpdateReporterCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/UpdateReporterCommand.java
@@ -32,6 +32,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
 import org.apache.sling.cli.impl.Command;
 import org.apache.sling.cli.impl.InputOption;
 import org.apache.sling.cli.impl.UserInput;
@@ -127,11 +128,17 @@ public class UpdateReporterCommand extends AbstractReleaseCommand {
                 parameters.add(new BasicNameValuePair("xdate", simpleDateFormat.format(now)));
                 post.setEntity(new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8));
                 try (CloseableHttpResponse response = client.execute(post)) {
-                    if (response.getStatusLine().getStatusCode() != 200) {
+                    int statusCode = response.getStatusLine().getStatusCode();
+                    // addrelease.py returns HTTP 200 even on failure, with the error in the body, so the
+                    // status code alone cannot tell success from failure.
+                    String body = response.getEntity() == null
+                            ? ""
+                            : EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8)
+                                    .strip();
+                    if (statusCode != 200 || body.contains("Could not save")) {
                         throw new IOException(String.format(
-                                "The Apache Reporter System update failed for release %s. Got response code "
-                                        + "%s instead of 200.",
-                                release.getFullName(), response.getStatusLine().getStatusCode()));
+                                "The Apache Reporter System update failed for release %s. HTTP %s%s",
+                                release.getFullName(), statusCode, body.isEmpty() ? "" : " - " + body));
                     }
                 }
             }

--- a/src/main/java/org/apache/sling/cli/impl/release/UpdateReporterCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/UpdateReporterCommand.java
@@ -108,7 +108,7 @@ public class UpdateReporterCommand extends AbstractReleaseCommand {
         try (CloseableHttpClient client = httpClientFactory.newClient()) {
             Set<String> alreadyRecorded = Reporter.fetchRegisteredReleaseNames(client);
             for (Release release : releases) {
-                if (alreadyRecorded != null && alreadyRecorded.contains(release.getFullName())) {
+                if (alreadyRecorded.contains(release.getFullName())) {
                     LOGGER.info("Apache Reporter already lists {}; skipping.", release.getFullName());
                     continue;
                 }

--- a/src/test/java/org/apache/sling/cli/impl/jira/ChangelogJiraAction.java
+++ b/src/test/java/org/apache/sling/cli/impl/jira/ChangelogJiraAction.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.cli.impl.jira;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.sun.net.httpserver.HttpExchange;
+
+/**
+ * Serves the change history for an issue GET such as {@code /jira/rest/api/2/issue/SLING-0006?expand=changelog}
+ * from a per-key classpath fixture under {@code /jira/changelog/}.
+ */
+public class ChangelogJiraAction implements JiraAction {
+
+    private static final Pattern ISSUE = Pattern.compile("/jira/rest/api/2/issue/([A-Za-z]+-\\d+)");
+
+    @Override
+    public boolean tryHandle(HttpExchange ex) throws IOException {
+        if (!ex.getRequestMethod().equals("GET")) {
+            return false;
+        }
+        Matcher matcher = ISSUE.matcher(ex.getRequestURI().getPath());
+        if (!matcher.matches()) {
+            return false;
+        }
+        String key = matcher.group(1);
+        try (var in = getClass().getResourceAsStream("/jira/changelog/" + key + ".json")) {
+            if (in == null) {
+                return false; // no fixture -> let the fallback handler answer
+            }
+        }
+        serveFileFromClasspath(ex, "/jira/changelog/" + key + ".json");
+        return true;
+    }
+}

--- a/src/test/java/org/apache/sling/cli/impl/jira/MockJira.java
+++ b/src/test/java/org/apache/sling/cli/impl/jira/MockJira.java
@@ -81,6 +81,7 @@ public class MockJira extends ExternalResource {
         actions.add(new CreateVersionJiraAction());
         actions.add(new IssuesSearchJiraAction());
         actions.add(new TransitionsJiraAction());
+        actions.add(new ChangelogJiraAction());
         actions.add(new EditVersionJiraAction());
 
         // fallback, always executed

--- a/src/test/java/org/apache/sling/cli/impl/jira/VersionClientTest.java
+++ b/src/test/java/org/apache/sling/cli/impl/jira/VersionClientTest.java
@@ -19,6 +19,7 @@
 package org.apache.sling.cli.impl.jira;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -191,5 +192,44 @@ public class VersionClientTest {
             throwable = e;
         }
         assertNull("Did not expect an error, since this case should be handled graciously.", throwable);
+    }
+
+    @Test
+    public void findIssuesFixVersionedAfterFindsLateTaggedIssues() throws IOException {
+        Release release = Release.fromString("Transitions 2.0.0").get(0);
+        // SLING-0006 acquired the fix version on 2019-09-20, i.e. after this instant
+        List<Issue> late = versionClient.findIssuesFixVersionedAfter(release, Instant.parse("2019-09-13T00:00:00Z"));
+        assertThat(late, hasSize(1));
+        assertThat(late.get(0).getKey(), equalTo("SLING-0006"));
+    }
+
+    @Test
+    public void releaseAbortsWhenIssueTaggedAfterStaging() {
+        Release release = Release.fromString("Transitions 2.0.0").get(0);
+        Exception exception = null;
+        try {
+            versionClient.release(release, Instant.parse("2019-09-13T00:00:00Z"));
+        } catch (Exception e) {
+            exception = e;
+        }
+        assertNotNull("Releasing should have been aborted because of a late-tagged issue.", exception);
+        assertTrue(
+                "SLING-0006 should have been reported as tagged after staging.",
+                exception.getMessage().contains("SLING-0006"));
+        assertTrue(
+                "Only the late-tagged issue should be reported.",
+                !exception.getMessage().contains("SLING-0004"));
+    }
+
+    @Test
+    public void releaseSucceedsWhenAllIssuesTaggedBeforeStaging() {
+        Release release = Release.fromString("Transitions 2.0.0").get(0);
+        Exception exception = null;
+        try {
+            versionClient.release(release, Instant.parse("2019-10-01T00:00:00Z"));
+        } catch (Exception e) {
+            exception = e;
+        }
+        assertNull("All issues were tagged before staging, so the release should have worked.", exception);
     }
 }

--- a/src/test/java/org/apache/sling/cli/impl/release/CreateJiraVersionCommandTest.java
+++ b/src/test/java/org/apache/sling/cli/impl/release/CreateJiraVersionCommandTest.java
@@ -80,7 +80,7 @@ public class CreateJiraVersionCommandTest {
         assertEquals(CommandLine.ExitCode.OK, (int) command.call());
 
         verify(versionClient, never()).create(anyString());
-        assertTrue(logCapture.containsMessage("would be created"));
+        assertTrue(logCapture.containsMessage("Would create JIRA version"));
     }
 
     @Test

--- a/src/test/java/org/apache/sling/cli/impl/release/FinalizeCommandTest.java
+++ b/src/test/java/org/apache/sling/cli/impl/release/FinalizeCommandTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.sling.cli.impl.Command;
 import org.apache.sling.cli.impl.Credentials;
@@ -192,6 +193,44 @@ public class FinalizeCommandTest {
         Command command = createCommand(123, ExecutionMode.AUTO);
         assertEquals(CommandLine.ExitCode.SOFTWARE, (int) command.call());
         assertTrue(logCapture.containsMessage("Failed executing command"));
+    }
+
+    @Test
+    public void testReporterReturns200WithErrorBodyFails() throws Exception {
+        prepare(false);
+        // addrelease.py returns HTTP 200 even on failure; a generic error body must surface as a failure
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(200);
+        CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+        when(response.getStatusLine()).thenReturn(statusLine);
+        when(response.getEntity()).thenReturn(new StringEntity("Could not save. Unexpected server error."));
+        when(client.execute(any())).thenReturn(response);
+
+        Command command = createCommand(123, ExecutionMode.AUTO);
+        assertEquals(CommandLine.ExitCode.SOFTWARE, (int) command.call());
+        assertTrue(logCapture.containsMessage("Failed executing command"));
+        // must NOT have falsely reported success
+        assertTrue(logCapture.getMessages().stream().noneMatch(m -> m.contains("Updated Apache Reporter")));
+    }
+
+    @Test
+    public void testReporterCommitteeAccessErrorWarnsButSucceeds() throws Exception {
+        prepare(false);
+        // the real reporter behaviour for a user without committee access: HTTP 200 + this message
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(200);
+        CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+        when(response.getStatusLine()).thenReturn(statusLine);
+        when(response.getEntity())
+                .thenReturn(new StringEntity("Could not save. Make sure you have filled out all fields and have"
+                        + " access to this committee data!"));
+        when(client.execute(any())).thenReturn(response);
+
+        Command command = createCommand(123, ExecutionMode.AUTO);
+        // a committee-access error is a known limitation (non-PMC), so it warns and finalize still completes
+        assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+        assertTrue(logCapture.containsMessage("lacks committee access"));
+        assertTrue(logCapture.getMessages().stream().noneMatch(m -> m.contains("Updated Apache Reporter")));
     }
 
     @Test

--- a/src/test/java/org/apache/sling/cli/impl/release/FinalizeCommandTest.java
+++ b/src/test/java/org/apache/sling/cli/impl/release/FinalizeCommandTest.java
@@ -47,7 +47,10 @@ import picocli.CommandLine;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -122,7 +125,7 @@ public class FinalizeCommandTest {
         prepare(false);
         Command command = createCommand(123, ExecutionMode.DRY_RUN);
         assertEquals(CommandLine.ExitCode.OK, (int) command.call());
-        assertTrue(logCapture.containsMessage("--- Step 2/5: Update dist.apache.org --- SKIPPED (current user is not a"
+        assertTrue(logCapture.containsMessage("--- Step 1/5: Update dist.apache.org --- SKIPPED (current user is not a"
                 + " PMC member; a PMC member must update dist.apache.org separately) ---"));
         // dry-run: nothing is actually promoted
         verify(repositoryService, never()).promote(any());
@@ -138,7 +141,7 @@ public class FinalizeCommandTest {
                     .thenReturn(List.of("org.apache.sling.cli.test-0.9.0.pom"));
             Command command = createCommand(123, ExecutionMode.DRY_RUN);
             assertEquals(CommandLine.ExitCode.OK, (int) command.call());
-            assertTrue(logCapture.containsMessage("--- Step 2/5: Update dist.apache.org ---"));
+            assertTrue(logCapture.containsMessage("--- Step 1/5: Update dist.apache.org ---"));
             // dry-run: dist is described, not committed
             dist.verify(() -> UpdateDistCommand.publishToDistRelease(any(), any(), any(), any(), any()), never());
         }
@@ -151,9 +154,10 @@ public class FinalizeCommandTest {
         assertEquals(CommandLine.ExitCode.OK, (int) command.call());
         // promoted to Maven Central, dist skipped, jira released, reporter updated
         verify(repositoryService).promote(any());
-        verify(versionClient).release(any());
-        verify(client).execute(any());
-        assertTrue(logCapture.containsMessage("--- Step 2/5: Update dist.apache.org --- SKIPPED (current user is not a"
+        verify(versionClient).release(any(), any());
+        // reporter now queries (GET overview) before posting (POST addrelease)
+        verify(client, atLeastOnce()).execute(any());
+        assertTrue(logCapture.containsMessage("--- Step 1/5: Update dist.apache.org --- SKIPPED (current user is not a"
                 + " PMC member; a PMC member must update dist.apache.org separately) ---"));
     }
 
@@ -171,7 +175,7 @@ public class FinalizeCommandTest {
             // dist upload is actually committed for a PMC member
             dist.verify(() -> UpdateDistCommand.publishToDistRelease(
                     eq("org.apache.sling.cli.test"), eq("1.0.0"), any(), any(), any()));
-            verify(versionClient).release(any());
+            verify(versionClient).release(any(), any());
         }
     }
 
@@ -223,9 +227,86 @@ public class FinalizeCommandTest {
         assertTrue(logCapture.containsMessage("Would create JIRA version CLI Test 1.0.2"));
     }
 
+    @Test
+    public void testPreflightAbortsBeforePromoteWhenIssueTaggedAfterStaging() throws Exception {
+        prepare(false);
+        StagingRepository repository = repositoryService.find(123);
+        when(repository.getCreated()).thenReturn(java.time.Instant.parse("2020-01-01T00:00:00Z"));
+        org.apache.sling.cli.impl.jira.Issue late = mock(org.apache.sling.cli.impl.jira.Issue.class);
+        when(late.getKey()).thenReturn("SLING-13260");
+        when(late.getSummary()).thenReturn("Late tagged issue");
+        when(versionClient.findIssuesFixVersionedAfter(any(), any())).thenReturn(List.of(late));
+
+        Command command = createCommand(123, ExecutionMode.AUTO);
+        assertEquals(CommandLine.ExitCode.SOFTWARE, (int) command.call());
+
+        assertTrue(logCapture.containsMessage("Refusing to release JIRA version Apache Sling CLI Test 1.0.0"));
+        assertTrue(logCapture.containsMessage("SLING-13260"));
+        assertTrue(logCapture.containsMessage("Aborting finalize before any changes are made."));
+        // the whole point: nothing irreversible ran, so the operator can fix JIRA and re-run
+        verify(repositoryService, never()).promote(any());
+        verify(versionClient, never()).release(any(), any());
+        assertTrue(logCapture.getMessages().stream().noneMatch(m -> m.contains("Step 1/5")));
+    }
+
+    @Test
+    public void testForceProceedsWhenIssueTaggedAfterStaging() throws Exception {
+        prepare(false);
+        StagingRepository repository = repositoryService.find(123);
+        when(repository.getCreated()).thenReturn(java.time.Instant.parse("2020-01-01T00:00:00Z"));
+        org.apache.sling.cli.impl.jira.Issue late = mock(org.apache.sling.cli.impl.jira.Issue.class);
+        when(late.getKey()).thenReturn("SLING-13260");
+        when(late.getSummary()).thenReturn("Late tagged issue");
+        when(versionClient.findIssuesFixVersionedAfter(any(), any())).thenReturn(List.of(late));
+
+        Command command = createCommand(123, ExecutionMode.AUTO, true);
+        assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+
+        assertTrue(logCapture.containsMessage("closing them anyway because --force-close-late-issues was given"));
+        // finalize proceeds through promote and release, forcing skips the guard via a null staged-at timestamp
+        verify(repositoryService).promote(any());
+        verify(versionClient).release(any(), isNull());
+        assertTrue(logCapture.containsMessage("Marked JIRA version Apache Sling CLI Test 1.0.0 as released"));
+    }
+
+    @Test
+    public void testResumeByNameSkipsPromoteAndDist() throws Exception {
+        prepare(true);
+        Command command = createCommandByName("Apache Sling CLI Test 1.0.0", ExecutionMode.AUTO);
+        assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+
+        assertTrue(logCapture.containsMessage("Resuming by release name"));
+        // the staging repository is gone, so promote/dist are skipped as already done...
+        verify(repositoryService, never()).find(anyInt());
+        verify(repositoryService, never()).promote(any());
+        assertTrue(logCapture.containsMessage("SKIPPED (staging repository already promoted and dropped)"));
+        // ...but the repository-independent JIRA release still runs (with no staging timestamp)
+        verify(versionClient).release(any(), isNull());
+    }
+
     private Command createCommand(int repositoryId, ExecutionMode executionMode) throws IllegalAccessException {
+        return createCommand(repositoryId, executionMode, false);
+    }
+
+    private Command createCommandByName(String releaseName, ExecutionMode executionMode) throws IllegalAccessException {
+        FinalizeCommand finalizeCommand = spy(new FinalizeCommand());
+        FieldUtils.writeField(finalizeCommand, "releaseName", releaseName, true);
+        ReusableCLIOptions reusableCLIOptions = mock(ReusableCLIOptions.class);
+        FieldUtils.writeField(reusableCLIOptions, "executionMode", executionMode, true);
+        FieldUtils.writeField(finalizeCommand, "reusableCLIOptions", reusableCLIOptions, true);
+        osgiContext.registerInjectActivateService(finalizeCommand);
+        Command result = osgiContext.getService(Command.class);
+        assertTrue(
+                "Expected to retrieve the FinalizeCommand from the mocked OSGi environment.",
+                result instanceof FinalizeCommand);
+        return result;
+    }
+
+    private Command createCommand(int repositoryId, ExecutionMode executionMode, boolean forceCloseLateIssues)
+            throws IllegalAccessException {
         FinalizeCommand finalizeCommand = spy(new FinalizeCommand());
         FieldUtils.writeField(finalizeCommand, "repositoryId", repositoryId, true);
+        FieldUtils.writeField(finalizeCommand, "forceCloseLateIssues", forceCloseLateIssues, true);
         ReusableCLIOptions reusableCLIOptions = mock(ReusableCLIOptions.class);
         FieldUtils.writeField(reusableCLIOptions, "executionMode", executionMode, true);
         FieldUtils.writeField(finalizeCommand, "reusableCLIOptions", reusableCLIOptions, true);

--- a/src/test/java/org/apache/sling/cli/impl/release/FinalizeCommandTest.java
+++ b/src/test/java/org/apache/sling/cli/impl/release/FinalizeCommandTest.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.cli.impl.release;
+
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.sling.cli.impl.Command;
+import org.apache.sling.cli.impl.Credentials;
+import org.apache.sling.cli.impl.CredentialsService;
+import org.apache.sling.cli.impl.ExecutionMode;
+import org.apache.sling.cli.impl.http.HttpClientFactory;
+import org.apache.sling.cli.impl.jira.VersionClient;
+import org.apache.sling.cli.impl.junit.LogCapture;
+import org.apache.sling.cli.impl.nexus.Artifact;
+import org.apache.sling.cli.impl.nexus.LocalRepository;
+import org.apache.sling.cli.impl.nexus.RepositoryService;
+import org.apache.sling.cli.impl.nexus.StagingRepository;
+import org.apache.sling.cli.impl.people.Member;
+import org.apache.sling.cli.impl.people.MembersFinder;
+import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import picocli.CommandLine;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class FinalizeCommandTest {
+
+    @Rule
+    public final OsgiContext osgiContext = new OsgiContext();
+
+    @Rule
+    public final LogCapture logCapture = new LogCapture(FinalizeCommand.class);
+
+    private RepositoryService repositoryService;
+    private VersionClient versionClient;
+    private CloseableHttpClient client;
+
+    /**
+     * Sets up all collaborators. {@code pmcMember} controls whether the current user is detected as
+     * a PMC member, which drives the dist.apache.org step.
+     */
+    private void prepare(boolean pmcMember) throws Exception {
+        StagingRepository stagingRepository = mock(StagingRepository.class);
+        when(stagingRepository.getRepositoryId()).thenReturn("orgapachesling-123");
+        when(stagingRepository.getDescription()).thenReturn("Apache Sling CLI Test 1.0.0");
+
+        repositoryService = mock(RepositoryService.class);
+        when(repositoryService.find(123)).thenReturn(stagingRepository);
+        Set<Release> releases =
+                Set.of(Release.fromString("Apache Sling CLI Test 1.0.0").get(0));
+        when(repositoryService.getReleases(stagingRepository)).thenReturn(releases);
+        Artifact pom =
+                new Artifact(stagingRepository, "org.apache.sling", "org.apache.sling.cli.test", "1.0.0", null, "pom");
+        LocalRepository localRepository = mock(LocalRepository.class);
+        when(repositoryService.download(stagingRepository)).thenReturn(localRepository);
+        when(localRepository.getArtifacts()).thenReturn(Set.of(pom));
+        when(localRepository.getRootFolder()).thenReturn(java.nio.file.Path.of("target"));
+
+        // Step 3/4 - keep JIRA interactions trivial: a successor version already exists and there are
+        // no unresolved issues, so nothing is created or moved.
+        versionClient = mock(VersionClient.class);
+        when(versionClient.findSuccessorVersion(any())).thenReturn(mock(org.apache.sling.cli.impl.jira.Version.class));
+        when(versionClient.findUnresolvedIssues(any())).thenReturn(List.of());
+
+        // Step 5 - the reporter HTTP POST returns 200.
+        HttpClientFactory httpClientFactory = mock(HttpClientFactory.class);
+        client = mock(CloseableHttpClient.class);
+        when(httpClientFactory.newClient()).thenReturn(client);
+        CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(200);
+        when(response.getStatusLine()).thenReturn(statusLine);
+        when(client.execute(any())).thenReturn(response);
+
+        CredentialsService credentialsService = mock(CredentialsService.class);
+        when(credentialsService.getAsfCredentials()).thenReturn(new Credentials("johndoe", "secret"));
+
+        MembersFinder membersFinder = mock(MembersFinder.class);
+        when(membersFinder.getCurrentMember()).thenReturn(new Member("johndoe", "John Doe", pmcMember));
+
+        osgiContext.registerService(RepositoryService.class, repositoryService);
+        osgiContext.registerService(VersionClient.class, versionClient);
+        osgiContext.registerService(HttpClientFactory.class, httpClientFactory);
+        osgiContext.registerService(CredentialsService.class, credentialsService);
+        osgiContext.registerService(MembersFinder.class, membersFinder);
+    }
+
+    @Test
+    public void testDryRunNonPmc() throws Exception {
+        prepare(false);
+        Command command = createCommand(123, ExecutionMode.DRY_RUN);
+        assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+        assertTrue(logCapture.containsMessage("--- Step 2/5: Update dist.apache.org --- SKIPPED (current user is not a"
+                + " PMC member; a PMC member must update dist.apache.org separately) ---"));
+        // dry-run: nothing is actually promoted
+        verify(repositoryService, never()).promote(any());
+    }
+
+    @Test
+    public void testDryRunPmc() throws Exception {
+        prepare(true);
+        try (MockedStatic<UpdateDistCommand> dist = mockStatic(UpdateDistCommand.class)) {
+            dist.when(() -> UpdateDistCommand.collectDownloadedFiles(any()))
+                    .thenReturn(List.of(java.nio.file.Path.of("org.apache.sling.cli.test-1.0.0.pom")));
+            dist.when(() -> UpdateDistCommand.listPreviousReleaseFiles(any(), any(), any()))
+                    .thenReturn(List.of("org.apache.sling.cli.test-0.9.0.pom"));
+            Command command = createCommand(123, ExecutionMode.DRY_RUN);
+            assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+            assertTrue(logCapture.containsMessage("--- Step 2/5: Update dist.apache.org ---"));
+            // dry-run: dist is described, not committed
+            dist.verify(() -> UpdateDistCommand.publishToDistRelease(any(), any(), any(), any(), any()), never());
+        }
+    }
+
+    @Test
+    public void testAutoNonPmc() throws Exception {
+        prepare(false);
+        Command command = createCommand(123, ExecutionMode.AUTO);
+        assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+        // promoted to Maven Central, dist skipped, jira released, reporter updated
+        verify(repositoryService).promote(any());
+        verify(versionClient).release(any());
+        verify(client).execute(any());
+        assertTrue(logCapture.containsMessage("--- Step 2/5: Update dist.apache.org --- SKIPPED (current user is not a"
+                + " PMC member; a PMC member must update dist.apache.org separately) ---"));
+    }
+
+    @Test
+    public void testAutoPmc() throws Exception {
+        prepare(true);
+        try (MockedStatic<UpdateDistCommand> dist = mockStatic(UpdateDistCommand.class)) {
+            dist.when(() -> UpdateDistCommand.collectDownloadedFiles(any()))
+                    .thenReturn(List.of(java.nio.file.Path.of("org.apache.sling.cli.test-1.0.0.pom")));
+            dist.when(() -> UpdateDistCommand.listPreviousReleaseFiles(any(), any(), any()))
+                    .thenReturn(List.of("org.apache.sling.cli.test-0.9.0.pom"));
+            Command command = createCommand(123, ExecutionMode.AUTO);
+            assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+            verify(repositoryService).promote(any());
+            // dist upload is actually committed for a PMC member
+            dist.verify(() -> UpdateDistCommand.publishToDistRelease(
+                    eq("org.apache.sling.cli.test"), eq("1.0.0"), any(), any(), any()));
+            verify(versionClient).release(any());
+        }
+    }
+
+    @Test
+    public void testReporterFailureReturnsSoftware() throws Exception {
+        prepare(false);
+        // the reporter POST now returns a non-200 status, which must surface as a SOFTWARE exit code
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(500);
+        CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+        when(response.getStatusLine()).thenReturn(statusLine);
+        when(client.execute(any())).thenReturn(response);
+
+        Command command = createCommand(123, ExecutionMode.AUTO);
+        assertEquals(CommandLine.ExitCode.SOFTWARE, (int) command.call());
+        assertTrue(logCapture.containsMessage("Failed executing command"));
+    }
+
+    @Test
+    public void testAutoCreatesNextJiraVersionAndMovesIssues() throws Exception {
+        prepare(false);
+        // no successor exists yet -> the next version is created; after creation a successor is found
+        org.apache.sling.cli.impl.jira.Version successor = mock(org.apache.sling.cli.impl.jira.Version.class);
+        when(successor.getName()).thenReturn("CLI Test 1.0.2");
+        when(versionClient.findSuccessorVersion(any())).thenReturn(null, successor);
+        org.apache.sling.cli.impl.jira.Issue issue = mock(org.apache.sling.cli.impl.jira.Issue.class);
+        when(versionClient.findUnresolvedIssues(any())).thenReturn(List.of(issue));
+
+        Command command = createCommand(123, ExecutionMode.AUTO);
+        assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+
+        verify(versionClient).create(any());
+        verify(versionClient).moveIssuesToNewVersion(any(), any(), any());
+    }
+
+    @Test
+    public void testDryRunDescribesNextJiraVersionAndIssues() throws Exception {
+        prepare(false);
+        when(versionClient.findSuccessorVersion(any())).thenReturn(null);
+        org.apache.sling.cli.impl.jira.Issue issue = mock(org.apache.sling.cli.impl.jira.Issue.class);
+        when(versionClient.findUnresolvedIssues(any())).thenReturn(List.of(issue));
+
+        Command command = createCommand(123, ExecutionMode.DRY_RUN);
+        assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+
+        // dry-run must not actually create versions or move issues
+        verify(versionClient, never()).create(any());
+        verify(versionClient, never()).moveIssuesToNewVersion(any(), any(), any());
+        assertTrue(logCapture.containsMessage("Would create JIRA version CLI Test 1.0.2"));
+    }
+
+    private Command createCommand(int repositoryId, ExecutionMode executionMode) throws IllegalAccessException {
+        FinalizeCommand finalizeCommand = spy(new FinalizeCommand());
+        FieldUtils.writeField(finalizeCommand, "repositoryId", repositoryId, true);
+        ReusableCLIOptions reusableCLIOptions = mock(ReusableCLIOptions.class);
+        FieldUtils.writeField(reusableCLIOptions, "executionMode", executionMode, true);
+        FieldUtils.writeField(finalizeCommand, "reusableCLIOptions", reusableCLIOptions, true);
+        osgiContext.registerInjectActivateService(finalizeCommand);
+        Command result = osgiContext.getService(Command.class);
+        assertTrue(
+                "Expected to retrieve the FinalizeCommand from the mocked OSGi environment.",
+                result instanceof FinalizeCommand);
+        return result;
+    }
+}

--- a/src/test/java/org/apache/sling/cli/impl/release/FinalizeCommandTest.java
+++ b/src/test/java/org/apache/sling/cli/impl/release/FinalizeCommandTest.java
@@ -136,10 +136,13 @@ public class FinalizeCommandTest {
     public void testDryRunPmc() throws Exception {
         prepare(true);
         try (MockedStatic<UpdateDistCommand> dist = mockStatic(UpdateDistCommand.class)) {
-            dist.when(() -> UpdateDistCommand.collectDownloadedFiles(any()))
-                    .thenReturn(List.of(java.nio.file.Path.of("org.apache.sling.cli.test-1.0.0.pom")));
-            dist.when(() -> UpdateDistCommand.listPreviousReleaseFiles(any(), any(), any()))
-                    .thenReturn(List.of("org.apache.sling.cli.test-0.9.0.pom"));
+            dist.when(() -> UpdateDistCommand.planDistRelease(any(), any(), any()))
+                    .thenReturn(new UpdateDistCommand.DistReleasePlan(
+                            "org.apache.sling.cli.test",
+                            "1.0.0",
+                            List.of(java.nio.file.Path.of("org.apache.sling.cli.test-1.0.0.pom")),
+                            List.of("org.apache.sling.cli.test-0.9.0.pom"),
+                            false));
             Command command = createCommand(123, ExecutionMode.DRY_RUN);
             assertEquals(CommandLine.ExitCode.OK, (int) command.call());
             assertTrue(logCapture.containsMessage("--- Step 1/5: Update dist.apache.org ---"));
@@ -166,10 +169,13 @@ public class FinalizeCommandTest {
     public void testAutoPmc() throws Exception {
         prepare(true);
         try (MockedStatic<UpdateDistCommand> dist = mockStatic(UpdateDistCommand.class)) {
-            dist.when(() -> UpdateDistCommand.collectDownloadedFiles(any()))
-                    .thenReturn(List.of(java.nio.file.Path.of("org.apache.sling.cli.test-1.0.0.pom")));
-            dist.when(() -> UpdateDistCommand.listPreviousReleaseFiles(any(), any(), any()))
-                    .thenReturn(List.of("org.apache.sling.cli.test-0.9.0.pom"));
+            dist.when(() -> UpdateDistCommand.planDistRelease(any(), any(), any()))
+                    .thenReturn(new UpdateDistCommand.DistReleasePlan(
+                            "org.apache.sling.cli.test",
+                            "1.0.0",
+                            List.of(java.nio.file.Path.of("org.apache.sling.cli.test-1.0.0.pom")),
+                            List.of("org.apache.sling.cli.test-0.9.0.pom"),
+                            false));
             Command command = createCommand(123, ExecutionMode.AUTO);
             assertEquals(CommandLine.ExitCode.OK, (int) command.call());
             verify(repositoryService).promote(any());

--- a/src/test/java/org/apache/sling/cli/impl/release/ReleaseJiraVersionCommandTest.java
+++ b/src/test/java/org/apache/sling/cli/impl/release/ReleaseJiraVersionCommandTest.java
@@ -42,6 +42,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -87,7 +89,7 @@ public class ReleaseJiraVersionCommandTest {
         prepare();
         Command command = createCommand(123, ExecutionMode.DRY_RUN);
         assertEquals(CommandLine.ExitCode.OK, (int) command.call());
-        verify(versionClient, never()).release(any());
+        verify(versionClient, never()).release(any(), any());
         assertTrue(logCapture.containsMessage("The following Jira versions would be released:"));
     }
 
@@ -100,7 +102,7 @@ public class ReleaseJiraVersionCommandTest {
                     .thenReturn(InputOption.YES);
             Command command = createCommand(123, ExecutionMode.INTERACTIVE);
             assertEquals(CommandLine.ExitCode.OK, (int) command.call());
-            verify(versionClient, times(1)).release(any());
+            verify(versionClient, times(1)).release(any(), any());
         }
     }
 
@@ -109,7 +111,7 @@ public class ReleaseJiraVersionCommandTest {
         prepare();
         Command command = createCommand(123, ExecutionMode.AUTO);
         assertEquals(CommandLine.ExitCode.OK, (int) command.call());
-        verify(versionClient, times(1)).release(any());
+        verify(versionClient, times(1)).release(any(), any());
     }
 
     @Test
@@ -118,13 +120,53 @@ public class ReleaseJiraVersionCommandTest {
         prepare();
         Command command = createCommandByName("Apache Sling CLI Test 1.0.0", ExecutionMode.AUTO);
         assertEquals(CommandLine.ExitCode.OK, (int) command.call());
-        verify(versionClient, times(1)).release(any());
+        verify(versionClient, times(1)).release(any(), any());
         verify(repositoryService, never()).find(anyInt());
     }
 
+    @Test
+    public void testGuardWarnsAndPassesStagingTimestamp() throws Exception {
+        prepare();
+        when(repositoryService.find(123).getCreated()).thenReturn(java.time.Instant.parse("2020-01-01T00:00:00Z"));
+        Issue late = mock(Issue.class);
+        when(late.getKey()).thenReturn("SLING-13260");
+        when(late.getSummary()).thenReturn("Late tagged issue");
+        when(versionClient.findIssuesFixVersionedAfter(any(), any())).thenReturn(List.of(late));
+
+        Command command = createCommand(123, ExecutionMode.AUTO, false);
+        assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+
+        assertTrue(logCapture.containsMessage("Refusing to release JIRA version Apache Sling CLI Test 1.0.0"));
+        assertTrue(logCapture.containsMessage("SLING-13260"));
+        // the staging timestamp is handed to release(), which is the authoritative guard
+        verify(versionClient).release(any(), eq(java.time.Instant.parse("2020-01-01T00:00:00Z")));
+    }
+
+    @Test
+    public void testForcePassesNullTimestamp() throws Exception {
+        prepare();
+        when(repositoryService.find(123).getCreated()).thenReturn(java.time.Instant.parse("2020-01-01T00:00:00Z"));
+        Issue late = mock(Issue.class);
+        when(late.getKey()).thenReturn("SLING-13260");
+        when(late.getSummary()).thenReturn("Late tagged issue");
+        when(versionClient.findIssuesFixVersionedAfter(any(), any())).thenReturn(List.of(late));
+
+        Command command = createCommand(123, ExecutionMode.AUTO, true);
+        assertEquals(CommandLine.ExitCode.OK, (int) command.call());
+
+        assertTrue(logCapture.containsMessage("closing them anyway because --force-close-late-issues was given"));
+        verify(versionClient).release(any(), isNull());
+    }
+
     private Command createCommand(int repositoryId, ExecutionMode executionMode) throws Exception {
+        return createCommand(repositoryId, executionMode, false);
+    }
+
+    private Command createCommand(int repositoryId, ExecutionMode executionMode, boolean forceCloseLateIssues)
+            throws Exception {
         ReleaseJiraVersionCommand releaseJiraVersionCommand = spy(new ReleaseJiraVersionCommand());
         FieldUtils.writeField(releaseJiraVersionCommand, "repositoryId", repositoryId, true);
+        FieldUtils.writeField(releaseJiraVersionCommand, "forceCloseLateIssues", forceCloseLateIssues, true);
         ReusableCLIOptions reusableCLIOptions = mock(ReusableCLIOptions.class);
         FieldUtils.writeField(reusableCLIOptions, "executionMode", executionMode, true);
         FieldUtils.writeField(releaseJiraVersionCommand, "reusableCLIOptions", reusableCLIOptions, true);

--- a/src/test/java/org/apache/sling/cli/impl/release/TallyVotesCommandTest.java
+++ b/src/test/java/org/apache/sling/cli/impl/release/TallyVotesCommandTest.java
@@ -113,8 +113,8 @@ public class TallyVotesCommandTest {
     @Test
     public void testDryRunNonPmc() throws Exception {
         // Daniel (a non-PMC committer) is the release manager running tally-votes; PMC status is
-        // auto-detected from the current user, so the result email asks a PMC member to do the dist
-        // upload.
+        // auto-detected from the current user, so the result email asks a PMC member to finalize the
+        // release (the dist upload must come first and is PMC-only).
         Mailer mailer = mock(Mailer.class);
         List<Email> thread = new ArrayList<>() {
             {
@@ -142,11 +142,14 @@ public class TallyVotesCommandTest {
                 +1 (binding): Alice, Bob, Charlie
                 +1 (non-binding): none
 
-                I will promote the artifacts to the central Maven repository.
+                The release still needs to be finalized: the artifacts must first be copied to the
+                Sling dist directory (https://dist.apache.org/repos/dist/release/sling/) and only
+                then promoted to the central Maven repository. As that first step requires PMC
+                membership, which I do not have, I cannot finalize this release myself.
 
-                As I am not a PMC member, I cannot copy the release to the dist directory myself.
-
-                ACTION NEEDED: can a PMC member please copy Apache Sling CLI Test 1.0.0 to the Sling dist directory (https://dist.apache.org/repos/dist/release/sling/)?
+                ACTION NEEDED: can a PMC member please finalize Apache Sling CLI Test 1.0.0 by copying it
+                to the dist directory and then promoting the staged artifacts to the central Maven
+                repository?
 
                 Regards,
                 Daniel

--- a/src/test/java/org/apache/sling/cli/impl/release/UpdateDistCommandTest.java
+++ b/src/test/java/org/apache/sling/cli/impl/release/UpdateDistCommandTest.java
@@ -287,6 +287,10 @@ public class UpdateDistCommandTest {
             dist.when(() -> UpdateDistCommand.listDistFiles(
                             eq(UpdateDistCommand.DIST_RELEASE_URL), eq(ARTIFACT + "-1.3.4")))
                     .thenReturn(List.of(ARTIFACT + "-1.3.4.pom"));
+            // the already-published probe queries the new version's prefix; it is not yet in dist/release
+            dist.when(() -> UpdateDistCommand.listDistFiles(
+                            eq(UpdateDistCommand.DIST_RELEASE_URL), eq(ARTIFACT + "-1.3.6")))
+                    .thenReturn(List.of());
             dist.when(() -> UpdateDistCommand.publishToDistRelease(any(), any(), any(), any(), any()))
                     .thenAnswer(invocation -> null);
 

--- a/src/test/java/org/apache/sling/cli/impl/release/UpdateReporterCommandTest.java
+++ b/src/test/java/org/apache/sling/cli/impl/release/UpdateReporterCommandTest.java
@@ -102,7 +102,7 @@ public class UpdateReporterCommandTest {
             when(statusLine.getStatusCode()).thenReturn(200);
             when(client.execute(any())).thenReturn(response);
             assertEquals(0, (int) updateReporter.call());
-            verify(client, times(2)).execute(any());
+            verify(client, times(3)).execute(any());
         }
     }
 
@@ -115,7 +115,7 @@ public class UpdateReporterCommandTest {
         when(statusLine.getStatusCode()).thenReturn(200);
         when(client.execute(any())).thenReturn(response);
         assertEquals(0, (int) updateReporter.call());
-        verify(client, times(2)).execute(any());
+        verify(client, times(3)).execute(any());
     }
 
     @Test
@@ -128,7 +128,7 @@ public class UpdateReporterCommandTest {
         when(statusLine.getStatusCode()).thenReturn(200);
         when(client.execute(any())).thenReturn(response);
         assertEquals(0, (int) updateReporter.call());
-        verify(client, times(1)).execute(any());
+        verify(client, times(2)).execute(any());
     }
 
     @Test

--- a/src/test/resources/jira/changelog/SLING-0004.json
+++ b/src/test/resources/jira/changelog/SLING-0004.json
@@ -1,0 +1,25 @@
+{
+    "id": "4",
+    "key": "SLING-0004",
+    "changelog": {
+        "startAt": 0,
+        "maxResults": 10,
+        "total": 1,
+        "histories": [
+            {
+                "id": "100400",
+                "created": "2019-09-01T10:00:00.000+0000",
+                "items": [
+                    {
+                        "field": "Fix Version",
+                        "fieldtype": "jira",
+                        "from": null,
+                        "fromString": null,
+                        "to": "10004",
+                        "toString": "Transitions 2.0.0"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/src/test/resources/jira/changelog/SLING-0005.json
+++ b/src/test/resources/jira/changelog/SLING-0005.json
@@ -1,0 +1,25 @@
+{
+    "id": "5",
+    "key": "SLING-0005",
+    "changelog": {
+        "startAt": 0,
+        "maxResults": 10,
+        "total": 1,
+        "histories": [
+            {
+                "id": "100500",
+                "created": "2019-09-02T12:30:00.000+0000",
+                "items": [
+                    {
+                        "field": "Fix Version",
+                        "fieldtype": "jira",
+                        "from": null,
+                        "fromString": null,
+                        "to": "10005",
+                        "toString": "Transitions 2.0.0"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/src/test/resources/jira/changelog/SLING-0006.json
+++ b/src/test/resources/jira/changelog/SLING-0006.json
@@ -1,0 +1,39 @@
+{
+    "id": "6",
+    "key": "SLING-0006",
+    "changelog": {
+        "startAt": 0,
+        "maxResults": 10,
+        "total": 2,
+        "histories": [
+            {
+                "id": "100600",
+                "created": "2019-09-05T09:00:00.000+0000",
+                "items": [
+                    {
+                        "field": "summary",
+                        "fieldtype": "jira",
+                        "from": null,
+                        "fromString": "old summary",
+                        "to": null,
+                        "toString": "Test Transitions 6"
+                    }
+                ]
+            },
+            {
+                "id": "100601",
+                "created": "2019-09-20T08:15:00.000+0000",
+                "items": [
+                    {
+                        "field": "Fix Version",
+                        "fieldtype": "jira",
+                        "from": null,
+                        "fromString": null,
+                        "to": "10006",
+                        "toString": "Transitions 2.0.0"
+                    }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Part of splitting #28 into per-command changes (final PR in the series).

**Jira:** https://issues.apache.org/jira/browse/SLING-13253

Adds `release finalize`, which runs all post-vote finalization steps in one command (promote to Maven Central, update dist.apache.org, create/release the JIRA version, and report to the Apache Reporter). Also lets the post-vote commands act on a release **by name** in addition to a staging repository id, adds tests for the JIRA-version and verify commands, and updates the README with the end-to-end workflow.

Stacked on the tally-votes PR.

---
**Stack (merge in order):** #29 list → #30 close-staging → #31 promote/drop → #32 update-dist → #33 tally-votes → #34 finalize