### PR TITLE
chore(deps): update to docker-maven-plugin v0.48.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -271,7 +271,7 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.40.1</version>
+                <version>0.48.1</version>
                 <configuration>
                     <images>
                         <image>
@@ -284,7 +284,6 @@
                             </build>
                         </image>
                     </images>
-                    <cleanup>try</cleanup>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
This ensures compatibility with Maven 3.10.0-rc1.

Also cleaned up the invalid configuration parameter 'cleanup'.