### PR TITLE
SLING-13253 - finalize: correct the command help description order

### DIFF
--- a/src/main/java/org/apache/sling/cli/impl/release/FinalizeCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/FinalizeCommand.java
@@ -73,9 +73,8 @@ import picocli.CommandLine;
         })
 @CommandLine.Command(
         name = FinalizeCommand.NAME,
-        description =
-                "Runs all post-vote finalization steps: promote to Maven Central, update JIRA, and report to Apache."
-                        + " When the current user is a PMC member, dist.apache.org is updated as well.",
+        description = "Runs all post-vote finalization steps, in order: update dist.apache.org (PMC members only),"
+                + " promote to Maven Central, update JIRA, and report to Apache.",
         subcommands = CommandLine.HelpCommand.class)
 public class FinalizeCommand implements Command {
 


### PR DESCRIPTION
The `finalize` command's one-line `@Command` description listed *promote to Maven Central* before the `dist.apache.org` update, but finalize uploads to dist **first** (the only repository-dependent step, done before promotion drops the staging repository) and then promotes.

Reorder the description to match the actual execution order (and the class Javadoc, which was already correct):

```
Runs all post-vote finalization steps, in order: update dist.apache.org (PMC members only), promote to Maven Central, update JIRA, and report to Apache.
```

Follow-up to the SLING-13253 finalize work (#34); a docs-side counterpart was corrected in apache/sling-site#282.