### PR TITLE
SLING-13253 - tally-votes: list all finalize steps in the result email

### DIFF
--- a/src/main/java/org/apache/sling/cli/impl/release/TallyVotesCommand.java
+++ b/src/main/java/org/apache/sling/cli/impl/release/TallyVotesCommand.java
@@ -89,6 +89,14 @@ public class TallyVotesCommand implements Command {
     @CommandLine.Mixin
     private ReusableCLIOptions reusableCLIOptions;
 
+    /** The steps {@link FinalizeCommand} performs, in the order it performs them. */
+    private static final String FINALIZE_STEPS = "  1. copy the artifacts to the Sling dist directory\n"
+            + "     (https://dist.apache.org/repos/dist/release/sling/)\n"
+            + "  2. promote the staged artifacts to the central Maven repository\n"
+            + "  3. create the next JIRA version and move any unresolved issues to it\n"
+            + "  4. mark the JIRA version as released\n"
+            + "  5. add the release to the Apache Reporter System";
+
     private static final String EMAIL_TEMPLATE;
 
     static {
@@ -199,20 +207,16 @@ public class TallyVotesCommand implements Command {
      * dist directory first and only then promoting the artifacts to Maven Central. Because the dist
      * upload is restricted to PMC members, a non-PMC release manager cannot perform the finalization
      * in the correct order and must ask a PMC member to finalize the release. PMC membership is derived
-     * from the current user, so no flag is needed.
+     * from the current user, so no flag is needed. Both variants list the same {@link #FINALIZE_STEPS},
+     * so the email states what finalizing actually involves rather than only its first two steps.
      */
     private String closingAction(String releaseFullName, boolean isPmcMember) {
         if (isPmcMember) {
-            return "I will copy this release to the Sling dist directory and\n"
-                    + "promote the artifacts to the central Maven repository.";
+            return "I will finalize this release:\n\n" + FINALIZE_STEPS;
         }
-        return "The release still needs to be finalized: the artifacts must first be copied to the\n"
-                + "Sling dist directory (https://dist.apache.org/repos/dist/release/sling/) and only\n"
-                + "then promoted to the central Maven repository. As that first step requires PMC\n"
-                + "membership, which I do not have, I cannot finalize this release myself.\n\n"
-                + "ACTION NEEDED: can a PMC member please finalize " + releaseFullName + " by copying it\n"
-                + "to the dist directory and then promoting the staged artifacts to the central Maven\n"
-                + "repository?";
+        return "This release still needs to be finalized:\n\n" + FINALIZE_STEPS + "\n\n"
+                + "Steps 1 and 5 require PMC membership, which I do not have.\n\n"
+                + "ACTION NEEDED: can a PMC member please finalize " + releaseFullName + "?";
     }
 
     // TODO - better detection of '+1' votes

--- a/src/test/java/org/apache/sling/cli/impl/release/TallyVotesCommandTest.java
+++ b/src/test/java/org/apache/sling/cli/impl/release/TallyVotesCommandTest.java
@@ -103,8 +103,14 @@ public class TallyVotesCommandTest {
                         + "+1 (binding): Alice, Bob, Charlie, John Doe, Joerg Hoh\n"
                         + "+1 (non-binding): Daniel\n"
                         + "\n"
-                        + "I will copy this release to the Sling dist directory and\n"
-                        + "promote the artifacts to the central Maven repository.\n"
+                        + "I will finalize this release:\n"
+                        + "\n"
+                        + "  1. copy the artifacts to the Sling dist directory\n"
+                        + "     (https://dist.apache.org/repos/dist/release/sling/)\n"
+                        + "  2. promote the staged artifacts to the central Maven repository\n"
+                        + "  3. create the next JIRA version and move any unresolved issues to it\n"
+                        + "  4. mark the JIRA version as released\n"
+                        + "  5. add the release to the Apache Reporter System\n"
                         + "\n"
                         + "Regards,\n"
                         + "John Doe\n"));
@@ -142,14 +148,18 @@ public class TallyVotesCommandTest {
                 +1 (binding): Alice, Bob, Charlie
                 +1 (non-binding): none
 
-                The release still needs to be finalized: the artifacts must first be copied to the
-                Sling dist directory (https://dist.apache.org/repos/dist/release/sling/) and only
-                then promoted to the central Maven repository. As that first step requires PMC
-                membership, which I do not have, I cannot finalize this release myself.
+                This release still needs to be finalized:
 
-                ACTION NEEDED: can a PMC member please finalize Apache Sling CLI Test 1.0.0 by copying it
-                to the dist directory and then promoting the staged artifacts to the central Maven
-                repository?
+                  1. copy the artifacts to the Sling dist directory
+                     (https://dist.apache.org/repos/dist/release/sling/)
+                  2. promote the staged artifacts to the central Maven repository
+                  3. create the next JIRA version and move any unresolved issues to it
+                  4. mark the JIRA version as released
+                  5. add the release to the Apache Reporter System
+
+                Steps 1 and 5 require PMC membership, which I do not have.
+
+                ACTION NEEDED: can a PMC member please finalize Apache Sling CLI Test 1.0.0?
 
                 Regards,
                 Daniel
@@ -204,8 +214,14 @@ public class TallyVotesCommandTest {
                         + "+1 (binding): Alice, Bob, Charlie, John Doe\n"
                         + "+1 (non-binding): Daniel\n"
                         + "\n"
-                        + "I will copy this release to the Sling dist directory and\n"
-                        + "promote the artifacts to the central Maven repository.\n"
+                        + "I will finalize this release:\n"
+                        + "\n"
+                        + "  1. copy the artifacts to the Sling dist directory\n"
+                        + "     (https://dist.apache.org/repos/dist/release/sling/)\n"
+                        + "  2. promote the staged artifacts to the central Maven repository\n"
+                        + "  3. create the next JIRA version and move any unresolved issues to it\n"
+                        + "  4. mark the JIRA version as released\n"
+                        + "  5. add the release to the Apache Reporter System\n"
                         + "\n"
                         + "Regards,\n"
                         + "John Doe\n");


### PR DESCRIPTION
The closing paragraph only mentioned the dist upload and the promotion to Maven Central, while finalize also creates the next JIRA version, moves unresolved issues, marks the version released and updates the Apache Reporter System. It also stated the dist-before-Central order twice, once in the explanation and again in the ACTION NEEDED line.

Both the PMC and non-PMC variants now share one FINALIZE_STEPS list that mirrors FinalizeCommand, and the ACTION NEEDED line carries only the ask.

Reporter data is committee-scoped, so a non-PMC releaser cannot complete that step either - the note now says steps 1 and 5 need PMC membership, not just the dist upload.